### PR TITLE
bridge_sector()$borderline is now logical

### DIFF
--- a/R/bridge_sector.R
+++ b/R/bridge_sector.R
@@ -43,6 +43,7 @@ bridge_sector <- function(data) {
     purrr::map(~ purrr::modify(.x, as.character)) %>%
     # Collapse the list of dataframes to a single, row-bind dataframe
     purrr::reduce(dplyr::bind_rows) %>%
+    purrr::modify_at("borderline", as.logical) %>%
     # Avoid duplicates
     unique() %>%
     # Reformat code_system

--- a/tests/testthat/test-bridge_sector.R
+++ b/tests/testthat/test-bridge_sector.R
@@ -1,6 +1,11 @@
 # bridge_sector() needs r2dii.dataraw in the search() path
 library(r2dii.dataraw)
 
+test_that("bridge_sector()$borderline is of type logical", {
+  out <- bridge_sector(r2dii.dataraw::loanbook_demo)
+  expect_is(out$borderline, "logical")
+})
+
 test_that("bridge_sector outputs known output", {
   out <- bridge_sector(r2dii.dataraw::loanbook_demo)
   expect_known_output(out, "ref-bridge_sector", update = FALSE)


### PR DESCRIPTION
It should always have been logical because `borderline` is logical
in all "classification_bridge" datasets.