### PR TITLE
prefer_perfect_match_by now groups by loan

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -56,7 +56,7 @@ match_name <- function(loanbook,
     pick_min_score(min_score) %>%
     restore_cols_sector_name_and_others(prep_lbk, prep_ald) %>%
     restore_cols_from_loanbook(loanbook) %>%
-    prefer_perfect_match_by(.data$alias_lbk)
+    prefer_perfect_match_by(.data$id_lbk)
 
   level_cols <- out %>%
     names_matching(level = get_level_columns())


### PR DESCRIPTION
Closes #70
Relates to https://github.com/2DegreesInvesting/r2dii.match/issues/40#issue-537565173
> In case there is a perfect match, all others should not be
  kept - no matter of the threshold
--@2diiKlaus

Before it grouped by `alias_lbk` and I believe that was a bug.