### PR TITLE
match_name output expected names even if no match

### DIFF
--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -48,6 +48,9 @@ argument \code{min_value} and the result of the column \code{score} for each loa
 \item If no row has \code{score} equal to 1, \code{match_name()} returns all rows where
 \code{score} is equal to or greater than \code{min_score}.
 }
+
+If there is no match the output is a 0-row tibble with the expected column
+names -- for type stability.
 }
 \description{
 \code{match_name()} scores the match between names in a loanbook dataset (columns


### PR DESCRIPTION
Closes #73.

match_name now correctly handles level columns, even for slices
of input loanboooks that lack some of the most comon levels, e.g.
a loanbook that has only `name_direct_loantaker` but no
`name_intermediate_parent_n` or `name_ultimate_parent`.

Also, match_name now outputs the expected names even if there is
no match -- in which case it returns a 0-row tibble with expected
names and a warning.