### PR TITLE
WIP: Row 5 of loanbook_demo exposes the bug

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -120,11 +120,11 @@ restore_cols_from_loanbook <- function(matched, loanbook) {
     tidyr::pivot_wider(
       names_from = "level_lbk",
       values_from = "name_lbk",
-      # FIXME: Do we really need this?
       names_prefix = "name_"
     )
 
   level_cols <- paste0("name_", unique(matched$level_lbk))
+
   left_join(
     suffix_names(with_level_cols, "_lbk", level_cols),
     suffix_names(loanbook, "_lbk"),
@@ -226,5 +226,16 @@ names_added_by_match_name <- function() {
     "alias_ald",
     "score",
     "source"
+  )
+}
+
+crucial_loanbook_names_for_match_name <- function() {
+  c(
+    "id_ultimate_parent",
+    "name_ultimate_parent",
+    "id_direct_loantaker",
+    "name_direct_loantaker",
+    "sector_classification_system",
+    "sector_classification_direct_loantaker"
   )
 }

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -253,3 +253,23 @@ test_that("match_nanme works with slice(loanbook_demo, 1)", {
     "no match"
   )
 })
+
+test_that("match_namne with slice 4:5 returns some non-NA in loanbook columns", {
+  good1 <- slice(loanbook_demo, 1)
+  good14 <- slice(loanbook_demo, 1:4)
+
+  # If slice 5 is included, the output has NA in all loanbook columns
+  bad15 <- slice(loanbook_demo, 1:5)
+  # Minimal data that exposes the bug
+  bad5 <- slice(loanbook_demo, 5)
+  bugger <- bad5 %>% select(crucial_loanbook_names_for_match_name())
+  out <- match_name(bugger, ald_demo)
+
+  loanbook_columns <- setdiff(names(out), names_added_by_match_name())
+  all_values_of_loanbook_columns_are_na <- out %>%
+    select(loanbook_columns) %>%
+    purrr::map_lgl(~ all(is.na(.x))) %>%
+    all()
+
+  expect_false(all_values_of_loanbook_columns_are_na)
+})


### PR DESCRIPTION
@jdhoffa, 

This commit leaves a failing test. I could not fix the but yet. So far I could only expose it. If you have time and want to, give it a go. Otherwise I'll come back to it ASAP.

``` r
suppressPackageStartupMessages(
  library(dplyr)
)
library(r2dii.dataraw)
#> Loading required package: r2dii.utils
library(r2dii.match)

bad5 <- slice(loanbook_demo, 5)
bugger <- bad5 %>% 
  select(r2dii.match:::crucial_loanbook_names_for_match_name())

bugger
#> # A tibble: 1 x 6
#>   id_ultimate_par… name_ultimate_p… id_direct_loant… name_direct_loa…
#>   <chr>            <chr>            <chr>            <chr>           
#> 1 UP104            Garland Power &… C305             Yukon Energy Co…
#> # … with 2 more variables: sector_classification_system <chr>,
#> #   sector_classification_direct_loantaker <dbl>

match_name(bugger, ald_demo)
#> # A tibble: 4 x 14
#>   id_ultimate_par… id_direct_loant… sector_classifi… sector_classifi… id   
#>   <chr>            <chr>            <chr>                       <dbl> <chr>
#> 1 <NA>             <NA>             <NA>                           NA UP1  
#> 2 <NA>             <NA>             <NA>                           NA UP1  
#> 3 <NA>             <NA>             <NA>                           NA C1   
#> 4 <NA>             <NA>             <NA>                           NA C1   
#> # … with 9 more variables: level <chr>, sector <chr>, sector_ald <chr>,
#> #   name <chr>, name_ald <chr>, alias <chr>, alias_ald <chr>, score <dbl>,
#> #   source <chr>
```

<sup>Created on 2020-01-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>
