### PR TITLE
`level` and `id` now correspond, but seems hacky

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2dii.match
 Title: Match Loanbook with Asset Level Data
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: 
     c(person(given = "Mauro",
              family = "Lepore",

--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -76,10 +76,10 @@ restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
     # FIXME: Here is where we loose intermediate_parent columns
     # fix input_cols_for_prepare_loanbook() to use all level_root columsn and
     # not fail is some is missing.
-    select(input_cols_for_prepare_loanbook(), .data$sector) %>%
+    select(rowid, input_cols_for_prepare_loanbook(), .data$sector) %>%
     identify_loans_by_sector_and_level() %>%
     identify_loans_by_name_and_source() %>%
-    select(output_cols_for_prepare_loanbook()) %>%
+    select(rowid, output_cols_for_prepare_loanbook()) %>%
     distinct() %>%
     may_overwrite_name_and_sector(overwrite = overwrite) %>%
     add_alias()

--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -74,9 +74,9 @@ restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
     may_add_sector_and_borderline() %>%
 
     # FIXME: Here is where we loose intermediate_parent columns
-    # fix input_cols_for_prepare_loanbook() to use all level_root columsn and
+    # fix input_cols_for_restructure_loanbook() to use all level_root columsn and
     # not fail is some is missing.
-    select(rowid, input_cols_for_prepare_loanbook(), .data$sector) %>%
+    select(rowid, input_cols_for_restructure_loanbook(), .data$sector) %>%
     identify_loans_by_sector_and_level() %>%
     identify_loans_by_name_and_source() %>%
     select(rowid, output_cols_for_prepare_loanbook()) %>%
@@ -126,14 +126,15 @@ add_alias <- function(data) {
 
 check_prepare_loanbook_data <- function(data) {
   stopifnot(is.data.frame(data))
-  check_crucial_names(data, input_cols_for_prepare_loanbook())
+  check_crucial_names(data, input_cols_for_restructure_loanbook())
   invisible(data)
 }
 
-input_cols_for_prepare_loanbook <- function() {
+input_cols_for_restructure_loanbook <- function() {
   # FIXME: This should not be hard coded but taken from the input loanbook, as
   # matching the values of level_root()
   c(
+    # "rowid",
     "id_direct_loantaker",
     "name_direct_loantaker",
     "id_ultimate_parent",

--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -64,9 +64,18 @@ restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
     call. = FALSE
   )
   data %>%
+    # FIXME: Maybe map uniquify_id_column over level_root(), then reduce rbind
+    # and may map prefix of intermediate_parent_1, _2, _n to IP1, IP2, IPn
+    # My only concent is that I haven't come up yet with a way to test if this
+    # really matters
     uniquify_id_column(id_column = "id_direct_loantaker", prefix = "C") %>%
     uniquify_id_column(id_column = "id_ultimate_parent", prefix = "UP") %>%
+
     may_add_sector_and_borderline() %>%
+
+    # FIXME: Here is where we loose intermediate_parent columns
+    # fix input_cols_for_prepare_loanbook() to use all level_root columsn and
+    # not fail is some is missing.
     select(input_cols_for_prepare_loanbook(), .data$sector) %>%
     identify_loans_by_sector_and_level() %>%
     identify_loans_by_name_and_source() %>%
@@ -122,6 +131,8 @@ check_prepare_loanbook_data <- function(data) {
 }
 
 input_cols_for_prepare_loanbook <- function() {
+  # FIXME: This should not be hard coded but taken from the input loanbook, as
+  # matching the values of level_root()
   c(
     "id_direct_loantaker",
     "name_direct_loantaker",

--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -75,10 +75,10 @@ restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
     # FIXME: Here is where we loose intermediate_parent columns
     # fix input_cols_for_restructure_loanbook() to use all level_root columsn and
     # not fail is some is missing.
-    select(rowid, input_cols_for_restructure_loanbook(), .data$sector) %>%
+    select(.data$rowid, input_cols_for_restructure_loanbook(), .data$sector) %>%
     identify_loans_by_sector_and_level() %>%
     identify_loans_by_name_and_source() %>%
-    select(rowid, output_cols_for_prepare_loanbook()) %>%
+    select(.data$rowid, output_cols_for_prepare_loanbook()) %>%
     distinct() %>%
     may_overwrite_name_and_sector(overwrite = overwrite) %>%
     add_alias()

--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -50,11 +50,11 @@ restructure_ald_for_matching <- function(data) {
 #' @examples
 #' library(r2dii.dataraw)
 #'
-#' loanbook_demo %>%
-#'   restructure_loanbook_for_matching()
+#' lbk <- tibble::rowid_to_column(loanbook_demo)
 #'
-#' loanbook_demo %>%
-#'   restructure_loanbook_for_matching(overwrite = overwrite_demo)
+#' restructure_loanbook_for_matching(lbk)
+#'
+#' restructure_loanbook_for_matching(lbk, overwrite = overwrite_demo)
 restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
   check_prepare_loanbook_overwrite(overwrite)
   check_prepare_loanbook_data(data)
@@ -70,7 +70,6 @@ restructure_loanbook_for_matching <- function(data, overwrite = NULL) {
     # really matters
     uniquify_id_column(id_column = "id_direct_loantaker", prefix = "C") %>%
     uniquify_id_column(id_column = "id_ultimate_parent", prefix = "UP") %>%
-
     may_add_sector_and_borderline() %>%
 
     # FIXME: Here is where we loose intermediate_parent columns
@@ -134,7 +133,7 @@ input_cols_for_restructure_loanbook <- function() {
   # FIXME: This should not be hard coded but taken from the input loanbook, as
   # matching the values of level_root()
   c(
-    # "rowid",
+    "rowid",
     "id_direct_loantaker",
     "name_direct_loantaker",
     "id_ultimate_parent",

--- a/R/score_alias_similarity.R
+++ b/R/score_alias_similarity.R
@@ -60,6 +60,9 @@ score_alias_similarity <- function(loanbook,
     out <- cross_alias(loanbook, ald)
   }
 
+  out <- out %>%
+    left_join(loanbook, by = c("alias_lbk" = "alias"))
+
   unique(
     mutate(
       out,

--- a/R/score_alias_similarity.R
+++ b/R/score_alias_similarity.R
@@ -29,23 +29,9 @@
 #'   alias = c("ya", "yb", "yc")
 #' )
 #'
-#' out <- score_alias_similarity(loanbook, ald)
+#' score_alias_similarity(loanbook, ald)
 #'
-#' # Recover sector
-#' left_join(out, loanbook, by = c("alias_lbk" = "alias"))
-#'
-#' threshold <- 0.5
-#' score_alias_similarity(loanbook, ald) %>%
-#'   filter(score >= threshold)
-#'
-#' out <- score_alias_similarity(loanbook, ald, by_sector = FALSE)
-#' out
-#'
-#' # Recover sectors from x & y
-#' left_join(out, loanbook, by = c("alias_lbk" = "alias")) %>%
-#'   rename(sector_x = sector) %>%
-#'   left_join(ald, by = c("alias_ald" = "alias")) %>%
-#'   rename(sector_y = sector)
+#' score_alias_similarity(loanbook, ald, by_sector = FALSE)
 score_alias_similarity <- function(loanbook,
                                    ald,
                                    ...,

--- a/README.md
+++ b/README.md
@@ -152,20 +152,21 @@ name matching algorithms, such as:
 
 ``` r
 match_name(your_loanbook, your_ald)
-#> # A tibble: 1,350 x 26
-#>    id_loan id_direct_loant… id_intermediate… id_ultimate_par… loan_size_outst…
-#>    <chr>   <chr>            <chr>            <chr>                       <dbl>
-#>  1 <NA>    <NA>             <NA>             <NA>                           NA
-#>  2 <NA>    <NA>             <NA>             <NA>                           NA
-#>  3 <NA>    <NA>             <NA>             <NA>                           NA
-#>  4 <NA>    <NA>             <NA>             <NA>                           NA
-#>  5 <NA>    <NA>             <NA>             <NA>                           NA
-#>  6 <NA>    <NA>             <NA>             <NA>                           NA
-#>  7 <NA>    <NA>             <NA>             <NA>                           NA
-#>  8 <NA>    <NA>             <NA>             <NA>                           NA
-#>  9 <NA>    <NA>             <NA>             <NA>                           NA
-#> 10 <NA>    <NA>             <NA>             <NA>                           NA
-#> # … with 1,340 more rows, and 21 more variables:
+#> # A tibble: 454 x 29
+#>    id_loan id_direct_loant… name_direct_loa… id_intermediate… name_intermedia…
+#>    <chr>   <chr>            <chr>            <chr>            <chr>           
+#>  1 L170    C203             Tesla Inc        <NA>             <NA>            
+#>  2 L180    C217             Weichai Power C… <NA>             <NA>            
+#>  3 L181    C218             Wheego           <NA>             <NA>            
+#>  4 L195    C313             Zhengzhou Yuton… <NA>             <NA>            
+#>  5 L174    C211             Tvr              <NA>             <NA>            
+#>  6 L198    C317             Ziyang Nanjun    <NA>             <NA>            
+#>  7 L193    C310             Zamyad           <NA>             <NA>            
+#>  8 L165    C195             Sunwin Bus       <NA>             <NA>            
+#>  9 L154    C171             Shandong Tangju… <NA>             <NA>            
+#> 10 L164    C193             Subaru Corp      <NA>             <NA>            
+#> # … with 444 more rows, and 24 more variables: id_ultimate_parent <chr>,
+#> #   name_ultimate_parent <chr>, loan_size_outstanding <dbl>,
 #> #   loan_size_outstanding_currency <chr>, loan_size_credit_limit <dbl>,
 #> #   loan_size_credit_limit_currency <chr>, sector_classification_system <chr>,
 #> #   sector_classification_input_type <chr>,
@@ -173,7 +174,7 @@ match_name(your_loanbook, your_ald)
 #> #   flag_project_finance_loan <chr>, name_project <lgl>,
 #> #   lei_direct_loantaker <lgl>, isin_direct_loantaker <lgl>, id <chr>,
 #> #   level <chr>, sector <chr>, sector_ald <chr>, name <chr>, name_ald <chr>,
-#> #   alias <chr>, alias_ald <chr>, score <dbl>, source <chr>
+#> #   alias_lbk <chr>, alias_ald <chr>, score <dbl>, source <chr>
 ```
 
 `match_name()` defaults to scoring matches between `alias_*` strings
@@ -184,12 +185,12 @@ a low score.
 ``` r
 match_name(your_loanbook, your_ald, by_sector = FALSE) %>% 
   nrow()
-#> [1] 1974
+#> [1] 662
 
 # Compare
 match_name(your_loanbook, your_ald, by_sector = TRUE) %>% 
   nrow()
-#> [1] 1350
+#> [1] 454
 ```
 
 `min_score` allows you to pick rows of a minimum `score` and above.
@@ -248,18 +249,18 @@ matched %>%
   prioritize() %>% 
   select(!!! some_interesting_columns)
 #> # A tibble: 402 x 5
-#>    id    level            alias                    alias_ald               score
-#>    <chr> <chr>            <chr>                    <chr>                   <dbl>
-#>  1 UP23  direct_loantaker astonmartin              astonmartin                 1
-#>  2 UP25  direct_loantaker avtozaz                  avtozaz                     1
-#>  3 UP36  direct_loantaker bogdan                   bogdan                      1
-#>  4 UP52  direct_loantaker chauto                   chauto                      1
-#>  5 UP53  direct_loantaker chehejia                 chehejia                    1
-#>  6 UP58  direct_loantaker chtcauto                 chtcauto                    1
-#>  7 UP80  direct_loantaker dongfenghonda            dongfenghonda               1
-#>  8 UP79  direct_loantaker dongfengluxgen           dongfengluxgen              1
-#>  9 UP89  direct_loantaker electricmobilitysolutio… electricmobilitysoluti…     1
-#> 10 UP94  direct_loantaker faradayfuture            faradayfuture               1
+#>    id    level         alias_lbk                 alias_ald                 score
+#>    <chr> <chr>         <chr>                     <chr>                     <dbl>
+#>  1 C167  direct_loant… shaanxiauto               shaanxiauto                   1
+#>  2 C168  direct_loant… shandongauto              shandongauto                  1
+#>  3 C169  direct_loant… shandongkama              shandongkama                  1
+#>  4 C170  direct_loant… shandongtangjunouling     shandongtangjunouling         1
+#>  5 C172  direct_loant… shanghaiautomotiveindust… shanghaiautomotiveindust…     1
+#>  6 C175  direct_loant… shanxidayun               shanxidayun                   1
+#>  7 C177  direct_loant… shenyangpolarsun          shenyangpolarsun              1
+#>  8 C179  direct_loant… shuanghuanauto            shuanghuanauto                1
+#>  9 C181  direct_loant… sichuanauto               sichuanauto                   1
+#> 10 C183  direct_loant… singulato                 singulato                     1
 #> # … with 392 more rows
 ```
 
@@ -267,7 +268,7 @@ The default priority is set internally via `prioritize_levels()`.
 
 ``` r
 prioritize_level(matched)
-#> [1] "direct_loantaker"      "intermediate_parent_1" "ultimate_parent"
+#> [1] "direct_loantaker" "ultimate_parent"
 ```
 
 You may use a different priority. One way to do that is to pass a
@@ -279,7 +280,7 @@ matched %>%
   prioritize(priority = rev) %>% 
   select(!!! some_interesting_columns)
 #> # A tibble: 402 x 5
-#>    id    level           alias                    alias_ald                score
+#>    id    level           alias_lbk                alias_ald                score
 #>    <chr> <chr>           <chr>                    <chr>                    <dbl>
 #>  1 UP23  ultimate_parent astonmartin              astonmartin                  1
 #>  2 UP25  ultimate_parent avtozaz                  avtozaz                      1
@@ -305,23 +306,23 @@ bad_idea <- select_chr(
 )
 
 bad_idea
-#> [1] "intermediate_parent_1" "ultimate_parent"       "direct_loantaker"
+#> [1] "ultimate_parent"  "direct_loantaker"
 
 matched %>% 
   prioritize(priority = bad_idea) %>% 
   select(!!! some_interesting_columns)
 #> # A tibble: 402 x 5
-#>    id    level               alias                  alias_ald              score
-#>    <chr> <chr>               <chr>                  <chr>                  <dbl>
-#>  1 UP23  intermediate_paren… astonmartin            astonmartin                1
-#>  2 UP25  intermediate_paren… avtozaz                avtozaz                    1
-#>  3 UP36  intermediate_paren… bogdan                 bogdan                     1
-#>  4 UP52  intermediate_paren… chauto                 chauto                     1
-#>  5 UP53  intermediate_paren… chehejia               chehejia                   1
-#>  6 UP58  intermediate_paren… chtcauto               chtcauto                   1
-#>  7 UP80  intermediate_paren… dongfenghonda          dongfenghonda              1
-#>  8 UP79  intermediate_paren… dongfengluxgen         dongfengluxgen             1
-#>  9 UP89  intermediate_paren… electricmobilitysolut… electricmobilitysolut…     1
-#> 10 UP94  intermediate_paren… faradayfuture          faradayfuture              1
+#>    id    level           alias_lbk                alias_ald                score
+#>    <chr> <chr>           <chr>                    <chr>                    <dbl>
+#>  1 UP23  ultimate_parent astonmartin              astonmartin                  1
+#>  2 UP25  ultimate_parent avtozaz                  avtozaz                      1
+#>  3 UP36  ultimate_parent bogdan                   bogdan                       1
+#>  4 UP52  ultimate_parent chauto                   chauto                       1
+#>  5 UP53  ultimate_parent chehejia                 chehejia                     1
+#>  6 UP58  ultimate_parent chtcauto                 chtcauto                     1
+#>  7 UP80  ultimate_parent dongfenghonda            dongfenghonda                1
+#>  8 UP79  ultimate_parent dongfengluxgen           dongfengluxgen               1
+#>  9 UP89  ultimate_parent electricmobilitysolutio… electricmobilitysolutio…     1
+#> 10 UP94  ultimate_parent faradayfuture            faradayfuture                1
 #> # … with 392 more rows
 ```

--- a/man/restructure_loanbook_for_matching.Rd
+++ b/man/restructure_loanbook_for_matching.Rd
@@ -26,11 +26,11 @@ from values in the columns \code{name_direct_loantaker} and
 \examples{
 library(r2dii.dataraw)
 
-loanbook_demo \%>\%
-  restructure_loanbook_for_matching()
+lbk <- tibble::rowid_to_column(loanbook_demo)
 
-loanbook_demo \%>\%
-  restructure_loanbook_for_matching(overwrite = overwrite_demo)
+restructure_loanbook_for_matching(lbk)
+
+restructure_loanbook_for_matching(lbk, overwrite = overwrite_demo)
 }
 \seealso{
 \link[r2dii.dataraw:loanbook_description]{r2dii.dataraw::loanbook_description}

--- a/man/score_alias_similarity.Rd
+++ b/man/score_alias_similarity.Rd
@@ -48,23 +48,9 @@ ald <- tibble(
   alias = c("ya", "yb", "yc")
 )
 
-out <- score_alias_similarity(loanbook, ald)
+score_alias_similarity(loanbook, ald)
 
-# Recover sector
-left_join(out, loanbook, by = c("alias_lbk" = "alias"))
-
-threshold <- 0.5
-score_alias_similarity(loanbook, ald) \%>\%
-  filter(score >= threshold)
-
-out <- score_alias_similarity(loanbook, ald, by_sector = FALSE)
-out
-
-# Recover sectors from x & y
-left_join(out, loanbook, by = c("alias_lbk" = "alias")) \%>\%
-  rename(sector_x = sector) \%>\%
-  left_join(ald, by = c("alias_ald" = "alias")) \%>\%
-  rename(sector_y = sector)
+score_alias_similarity(loanbook, ald, by_sector = FALSE)
 }
 \seealso{
 \link{match_name}.

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -4,6 +4,12 @@ library(r2dii.dataraw)
 test_that("match_name has expected names", {
   expected <- c(
     "id_loan",
+    "id_direct_loantaker",
+    "name_direct_loantaker",
+    "id_intermediate_parent_1",
+    "name_intermediate_parent_1",
+    "id_ultimate_parent",
+    "name_ultimate_parent",
     "loan_size_outstanding",
     "loan_size_outstanding_currency",
     "loan_size_credit_limit",
@@ -22,7 +28,7 @@ test_that("match_name has expected names", {
     "sector_ald",
     "name",
     "name_ald",
-    "alias",
+    "alias_lbk",
     "alias_ald",
     "score",
     "source"

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -1,11 +1,12 @@
 library(dplyr)
+library(r2dii.dataraw)
 
 test_that("prioritize works with loanbook_demo and ald_demo", {
   expect_error(
     loanbook_demo %>%
       slice(4:5) %>%
       match_name(ald_demo) %>%
-      prioritize(),
+      prioritize(priority = "ultimate_parent"),
     NA
   )
 })

--- a/tests/testthat/test-restructure_loanbook_for_matching.R
+++ b/tests/testthat/test-restructure_loanbook_for_matching.R
@@ -1,35 +1,38 @@
 library(r2dii.dataraw)
 
+loanbook_rowid <- loanbook_demo %>%
+  tibble::rowid_to_column()
+
 test_that("restructure_loanbook_for_matching warns overwriting id_ vars", {
   expect_message(
-    restructure_loanbook_for_matching(loanbook_demo),
+    restructure_loanbook_for_matching(loanbook_rowid),
     "Uniquifying.*id_direct_loantaker"
   )
 
   expect_message(
-    restructure_loanbook_for_matching(loanbook_demo),
+    restructure_loanbook_for_matching(loanbook_rowid),
     "Uniquifying.*id_ultimate_parent"
   )
 })
 
 test_that("restructure_loanbook_for_matching cals uniquify_id_column()", {
-  lbk <- loanbook_demo %>%
+  lbk <- loanbook_rowid %>%
     uniquify_id_column(id_column = "id_direct_loantaker", prefix = "UP") %>%
     uniquify_id_column(id_column = "id_ultimate_parent", prefix = "UP")
 
   expect_equal(
-    restructure_loanbook_for_matching(loanbook_demo),
+    restructure_loanbook_for_matching(loanbook_rowid),
     restructure_loanbook_for_matching(lbk)
   )
 })
 
 test_that("restructure_loanbook_for_matching may input add_sector_and_borderline(data)", {
   expect_warning(
-    out <- restructure_loanbook_for_matching(add_sector_and_borderline(loanbook_demo)),
+    out <- restructure_loanbook_for_matching(add_sector_and_borderline(loanbook_rowid)),
     "Using existing columns `sector` and `borderline`."
   )
 
-  expect_equal(out, restructure_loanbook_for_matching(loanbook_demo))
+  expect_equal(out, restructure_loanbook_for_matching(loanbook_rowid))
 })
 
 test_that("restructure_loanbook_for_matching errors gracefully with bad input", {
@@ -39,42 +42,37 @@ test_that("restructure_loanbook_for_matching errors gracefully with bad input", 
   )
 
   expect_error(
-    restructure_loanbook_for_matching(loanbook_demo, overwrite = "bad"),
+    restructure_loanbook_for_matching(loanbook_rowid, overwrite = "bad"),
     "data.frame.*is not TRUE"
   )
 })
 
-test_that("restructure_loanbook_for_matching", {
-  out <- restructure_loanbook_for_matching(loanbook_demo)
-  expect_false(any(duplicated(out$id)))
-})
-
 test_that("restructure_loanbook_for_matching outputs a tibble with expected names", {
-  out <- restructure_loanbook_for_matching(loanbook_demo)
+  out <- restructure_loanbook_for_matching(loanbook_rowid)
   expect_is(out, "tbl_df")
   expect_named(
     out,
-    c("level", "id", "name", "sector", "source", "alias")
+    c("rowid", "level", "id", "name", "sector", "source", "alias")
   )
 
-  out2 <- restructure_loanbook_for_matching(loanbook_demo, overwrite_demo)
+  out2 <- restructure_loanbook_for_matching(loanbook_rowid, overwrite_demo)
   expect_is(out2, "tbl_df")
   expect_named(
     out2,
-    c("level", "id", "name", "sector", "source", "alias")
+    c("rowid", "level", "id", "name", "sector", "source", "alias")
   )
 })
 
 test_that("restructure_loanbook_for_matching errors with bad overwrite columns", {
   expect_error(
-    restructure_loanbook_for_matching(loanbook_demo, overwrite = tibble(bad = 1)),
+    restructure_loanbook_for_matching(loanbook_rowid, overwrite = tibble(bad = 1)),
     "data must have all expected names"
   )
 })
 
 test_that("restructure_loanbook_for_matching correctly overwrites name", {
   overwrite <- overwrite_demo
-  out <- restructure_loanbook_for_matching(loanbook_demo, overwrite_demo) %>%
+  out <- restructure_loanbook_for_matching(loanbook_rowid, overwrite_demo) %>%
     filter(id %in% overwrite$id & level %in% overwrite$level) %>%
     left_join(overwrite, by = c("id", "level"))
 
@@ -83,7 +81,7 @@ test_that("restructure_loanbook_for_matching correctly overwrites name", {
 
 test_that("restructure_loanbook_for_matching correctly overwrites sector", {
   overwrite <- overwrite_demo
-  out <- restructure_loanbook_for_matching(loanbook_demo, overwrite_demo) %>%
+  out <- restructure_loanbook_for_matching(loanbook_rowid, overwrite_demo) %>%
     filter(id %in% overwrite$id & level %in% overwrite$level) %>%
     left_join(overwrite, by = c("id", "level"))
 

--- a/tests/testthat/test-score_alias_similarity.R
+++ b/tests/testthat/test-score_alias_similarity.R
@@ -50,18 +50,25 @@ test_that("score_alias_similarity scores extreme cases correctly", {
 })
 
 test_that("score_alias_similarity w/out crucial cols errors gracefully", {
+  good <- tibble(sector = "A", alias = "a")
+  y <- tibble(sector = "A", alias = "a")
+  expect_error(
+    score_alias_similarity(good, y),
+    NA
+  )
+
   bad <- tibble(alias = "a")
   y <- tibble(sector = "A", alias = "a")
   expect_error(
     score_alias_similarity(bad, y),
-    "must have.*alias"
+    "must have.*"
   )
 
-  bad <- tibble(sector = "A")
+  bad <- tibble(rowid = 1, sector = "A")
   y <- tibble(sector = "A", alias = "a")
   expect_error(
     score_alias_similarity(bad, y),
-    "must have.*sector"
+    "must have.*"
   )
 })
 

--- a/tests/testthat/test-score_alias_similarity.R
+++ b/tests/testthat/test-score_alias_similarity.R
@@ -13,12 +13,12 @@ test_that("score_alias_similarity has the expected names", {
 
   expect_named(
     score_alias_similarity(x, y),
-    c("alias_lbk", "alias_ald", "score")
+    c("alias_lbk", "alias_ald", "sector", "score")
   )
 
   expect_named(
     score_alias_similarity(x, y, by_sector = FALSE),
-    c("alias_lbk", "alias_ald", "score")
+    c("alias_lbk", "alias_ald", "sector", "score")
   )
 })
 
@@ -39,11 +39,13 @@ test_that("score_alias_similarity scores extreme cases correctly", {
   y <- tibble(sector = c("A", "B"), alias = c("a", "cd"))
   expect_equal(
     score_alias_similarity(x, y),
+    # styler: off
     tribble(
-      ~alias_lbk, ~alias_ald, ~score,
-      "a", "a", 1,
-      "ab", "cd", 0,
+      ~alias_lbk, ~alias_ald, ~sector,  ~score,
+      "a",        "a",        "A",      1,
+      "ab",       "cd",       "B",      0,
     )
+    # styler: on
   )
 })
 
@@ -164,13 +166,14 @@ test_that("score_alias_similarity w/ same `alias` in 2 sectors and
   y <- tibble(sector = "A", alias = "a")
   expect_equal(
     score_alias_similarity(x, y, by_sector = TRUE),
-    tibble(alias_lbk = "a", alias_ald = "a", score = 1)
+    tibble(alias_lbk = "a", alias_ald = "a", sector = c("A", "B"), score = 1)
   )
 })
 
 test_that("score_alias_similarity outputs unique rows", {
   # Known problematic data
   lbk <- loanbook_demo %>%
+    tibble::rowid_to_column() %>%
     filter(name_direct_loantaker == "Tata Group")
 
   out <- score_alias_similarity(


### PR DESCRIPTION
* `level` and `id` now correspond, but seems hacky.

Also, 
* Remove from the output the columns matching the pattern
  id_<level>. These columns redundant with the data under the
  columns `level`, and `id`

--

@jdhoffa, can you please check if this makes sense?

``` r
suppressPackageStartupMessages(
  library(dplyr)
)
library(r2dii.dataraw)
#> Loading required package: r2dii.utils
library(r2dii.match)

out <- loanbook_demo %>% 
  slice(1) %>% 
  match_name(ald_demo)

# Does this make sense?
out %>% select(id:last_col())
#> # A tibble: 9 x 10
#>   id    level  sector sector_ald name    name_ald   alias alias_ald score source
#>   <chr> <chr>  <chr>  <chr>      <chr>   <chr>      <chr> <chr>     <dbl> <chr> 
#> 1 UP15  ultim… power  power      Alpine… alpine kn… alpi… alpinekn…     1 loanb…
#> 2 UP15  ultim… power  power      Yuamen… alpine kn… alpi… alpinekn…     1 loanb…
#> 3 UP15  ultim… power  power      <NA>    alpine kn… alpi… alpinekn…     1 loanb…
#> 4 C294  direc… power  power      Alpine… alpine kn… alpi… alpinekn…     1 loanb…
#> 5 C294  direc… power  power      Yuamen… alpine kn… alpi… alpinekn…     1 loanb…
#> 6 C294  direc… power  power      <NA>    alpine kn… alpi… alpinekn…     1 loanb…
#> 7 <NA>  inter… power  power      Alpine… alpine kn… alpi… alpinekn…     1 loanb…
#> 8 <NA>  inter… power  power      Yuamen… alpine kn… alpi… alpinekn…     1 loanb…
#> 9 <NA>  inter… power  power      <NA>    alpine kn… alpi… alpinekn…     1 loanb…

# The match comes from a single loanbook-row, so it makes sense that it is
# multiplicated
out %>% 
  select(1:isin_direct_loantaker) %>% 
  unique()
#> # A tibble: 1 x 13
#>   id_loan loan_size_outst… loan_size_outst… loan_size_credi… loan_size_credi…
#>   <chr>              <dbl> <chr>                       <dbl> <chr>           
#> 1 L1                225625 EUR                      18968805 EUR             
#> # … with 8 more variables: sector_classification_system <chr>,
#> #   sector_classification_input_type <chr>,
#> #   sector_classification_direct_loantaker <dbl>, fi_type <chr>,
#> #   flag_project_finance_loan <chr>, name_project <lgl>,
#> #   lei_direct_loantaker <lgl>, isin_direct_loantaker <lgl>

# Bug remains
loanbook_demo %>% 
  slice(1:5) %>% 
  match_name(ald_demo)
#> # A tibble: 36 x 23
#>    id_loan loan_size_outst… loan_size_outst… loan_size_credi… loan_size_credi…
#>    <chr>              <dbl> <chr>                       <dbl> <chr>           
#>  1 <NA>                  NA <NA>                           NA <NA>            
#>  2 <NA>                  NA <NA>                           NA <NA>            
#>  3 <NA>                  NA <NA>                           NA <NA>            
#>  4 <NA>                  NA <NA>                           NA <NA>            
#>  5 <NA>                  NA <NA>                           NA <NA>            
#>  6 <NA>                  NA <NA>                           NA <NA>            
#>  7 <NA>                  NA <NA>                           NA <NA>            
#>  8 <NA>                  NA <NA>                           NA <NA>            
#>  9 <NA>                  NA <NA>                           NA <NA>            
#> 10 <NA>                  NA <NA>                           NA <NA>            
#> # … with 26 more rows, and 18 more variables:
#> #   sector_classification_system <chr>, sector_classification_input_type <chr>,
#> #   sector_classification_direct_loantaker <dbl>, fi_type <chr>,
#> #   flag_project_finance_loan <chr>, name_project <lgl>,
#> #   lei_direct_loantaker <lgl>, isin_direct_loantaker <lgl>, id <chr>,
#> #   level <chr>, sector <chr>, sector_ald <chr>, name <chr>, name_ald <chr>,
#> #   alias <chr>, alias_ald <chr>, score <dbl>, source <chr>
```

<sup>Created on 2020-01-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>
