### PR TITLE
Expose potential bug in prioritize() (#101)

### DIFF
--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -23,11 +23,11 @@
 #' library(dplyr)
 #'
 #' matched <- tribble(
-#'   ~score, ~id, ~level,
-#'   1, "aa", "ultimate_parent",
-#'   1, "aa", "direct_loantaker",
-#'   1, "bb", "intermediate_parent",
-#'   1, "bb", "ultimate_parent",
+#'   ~sector, ~sector_ald, ~score,  ~id,  ~level,
+#'   "coal",  "coal",      1,       "aa", "ultimate_parent",
+#'   "coal",  "coal",      1,       "aa", "direct_loantaker",
+#'   "coal",  "coal",      1,       "bb", "intermediate_parent",
+#'   "coal",  "coal",      1,       "bb", "ultimate_parent",
 #' )
 #'
 #' prioritize_level(matched)

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -46,14 +46,14 @@
 #'
 #' prioritize(matched, priority = bad_idea)
 prioritize <- function(data, priority = NULL) {
-  check_crucial_names(data, c("id", "level", "score"))
+  check_crucial_names(data, c("id", "level", "score", "sector_ald"))
   priority <- set_priority(data, priority = priority)
 
   old_groups <- dplyr::groups(data)
   perfect_matches <- filter(ungroup(data), .data$score == 1L)
 
   out <- perfect_matches %>%
-    group_by(.data$id) %>%
+    group_by(.data$id, .data$sector_ald) %>%
     prioritize_at(.at = "level", priority = priority) %>%
     ungroup()
 

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -46,14 +46,14 @@
 #'
 #' prioritize(matched, priority = bad_idea)
 prioritize <- function(data, priority = NULL) {
-  check_crucial_names(data, c("id", "level", "score", "sector_ald"))
+  check_crucial_names(data, c("id", "level", "score", "sector", "sector_ald"))
   priority <- set_priority(data, priority = priority)
 
   old_groups <- dplyr::groups(data)
   perfect_matches <- filter(ungroup(data), .data$score == 1L)
 
   out <- perfect_matches %>%
-    group_by(.data$id, .data$sector_ald) %>%
+    group_by(.data$id, .data$sector, .data$sector_ald) %>%
     prioritize_at(.at = "level", priority = priority) %>%
     ungroup()
 

--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -34,11 +34,11 @@ This function ignores but preserves existing groups them.
 library(dplyr)
 
 matched <- tribble(
-  ~score, ~id, ~level,
-  1, "aa", "ultimate_parent",
-  1, "aa", "direct_loantaker",
-  1, "bb", "intermediate_parent",
-  1, "bb", "ultimate_parent",
+  ~sector, ~sector_ald, ~score,  ~id,  ~level,
+  "coal",  "coal",      1,       "aa", "ultimate_parent",
+  "coal",  "coal",      1,       "aa", "direct_loantaker",
+  "coal",  "coal",      1,       "bb", "intermediate_parent",
+  "coal",  "coal",      1,       "bb", "ultimate_parent",
 )
 
 prioritize_level(matched)

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -1,6 +1,17 @@
 library(dplyr)
 library(r2dii.dataraw)
 
+test_that("prioritize w/ 2 identical rows except for sector yields 2 rows", {
+  matched <- tibble::tribble(
+    ~id_loan,   ~id,             ~level, ~score,  ~sector_ald,      ~sector,
+      "L162", "UP1",  "ultimate_parent",      1, "automotive",   "shipping",
+      "L162", "UP1",  "ultimate_parent",      1, "automotive", "automotive",
+  )
+  # styler: on
+
+  expect_equal(nrow(prioritize(matched)), 2L)
+})
+
 test_that("prioritize w/ 2 identical rows except for sector_ald yields 2 rows", {
   # Minimal data derived from
   # loanbook_demo %>% filter(id_loan == "L162")

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -39,7 +39,12 @@ test_that("prioritize w/ full demo datasets throws no error", {
 test_that("prioritize errors gracefully if data lacks crucial columns", {
   expect_error(prioritize(tibble(bad = 1)), "must have.*names")
 
-  matched <- tibble(id = "a", level = "a", score = 1, sector_ald = "coal")
+  matched <- tibble(
+      id = "a",
+      level = "a",
+      score = 1,
+      sector_ald = "coal",
+      sector = "coal")
   expect_error(prioritize(matched), NA)
 
   expect_error(
@@ -58,11 +63,19 @@ test_that("prioritize errors gracefully if data lacks crucial columns", {
     prioritize(select(matched, -sector_ald)),
     "must have.*names"
   )
+  expect_error(
+    prioritize(select(matched, -sector)),
+    "must have.*names"
+  )
 })
 
 test_that("prioritize errors gracefully with bad `priority`", {
   matched <- tibble(
-    id = "a", level = c("z", "a"), score = 1, sector_ald = "coal"
+    id = "a",
+    level = c("z", "a"),
+    score = 1,
+    sector_ald = "coal",
+    sector = "coal"
   )
   expect_warning(
     prioritize(matched, priority = c("bad1", "bab2")),
@@ -77,9 +90,9 @@ test_that("prioritize errors gracefully with bad `priority`", {
 test_that("prioritize picks score equal to 1", {
   # styler: off
   matched <- tibble::tribble(
-    ~id,             ~level, ~score, ~sector_ald,
-   "aa", "direct_loantaker",      1,      "coal",
-   "bb", "direct_loantaker",    0.9,      "coal",
+    ~id,             ~level, ~score, ~sector_ald, ~sector,
+   "aa", "direct_loantaker",      1,      "coal",  "coal",
+   "bb", "direct_loantaker",    0.9,      "coal",  "coal",
     )
   # styler: on
 
@@ -89,11 +102,11 @@ test_that("prioritize picks score equal to 1", {
 test_that("prioritize picks priority level per loan", {
   # styler: off
   matched <- tibble::tribble(
-    ~id,                 ~level, ~sector_ald, ~score,
-   "aa",      "ultimate_parent",      "coal",      1,
-   "aa",     "direct_loantaker",      "coal",      1,  # pick this
-   "bb",  "intermediate_parent",      "coal",      1,  # pick this
-   "bb",      "ultimate_parent",      "coal",      1,
+    ~id,                 ~level,     ~sector,~sector_ald, ~score,
+   "aa",      "ultimate_parent",      "coal",     "coal",      1,
+   "aa",     "direct_loantaker",      "coal",     "coal",      1,  # pick this
+   "bb",  "intermediate_parent",      "coal",     "coal",      1,  # pick this
+   "bb",      "ultimate_parent",      "coal",     "coal",      1,
     )
   # styler: on
 
@@ -106,11 +119,11 @@ test_that("prioritize picks priority level per loan", {
 test_that("prioritize picks the highetst level per loan", {
   # styler: off
   matched <- tibble::tribble(
-    ~id,                 ~level, ~sector_ald, ~score,
-    "aa",     "ultimate_parent",      "coal",      1,
-    "aa",    "direct_loantaker",      "coal",      1,  # pick this
-    "bb", "intermediate_parent",      "coal",      1,  # pick this
-    "bb",     "ultimate_parent",      "coal",      1,
+    ~id,                 ~level, ~sector_ald,     ~sector, ~score,
+    "aa",     "ultimate_parent",      "coal",      "coal",      1,
+    "aa",    "direct_loantaker",      "coal",      "coal",      1,  # pick this
+    "bb", "intermediate_parent",      "coal",      "coal",      1,  # pick this
+    "bb",     "ultimate_parent",      "coal",      "coal",      1,
     )
   # styler: on
 
@@ -123,7 +136,13 @@ test_that("prioritize picks the highetst level per loan", {
 test_that("prioritize takes a `priority` function
           or lambda", {
   level <- c("direct_loantaker", "ultimate_parent")
-  matched <- tibble(id = "aa", level, score = 1, sector_ald = "coal")
+  matched <- tibble(
+      id = "aa",
+      level,
+      score = 1,
+      sector_ald = "coal",
+      sector = "coal"
+    )
 
   out <- prioritize(matched, priority = NULL)
   expect_equal(out$level, "direct_loantaker")
@@ -139,7 +158,11 @@ test_that("prioritize takes a `priority` function
 
 test_that("prioritize is sensitive to `priority`", {
   matched <- tibble(
-    id = "aa", level = c("z", "a"), score = 1, sector_ald = "coal"
+    id = "aa",
+    level = c("z", "a"),
+    score = 1,
+    sector_ald = "coal",
+    sector = "coal"
   )
   expect_equal(
     prioritize(matched, priority = "z")$level,
@@ -150,11 +173,11 @@ test_that("prioritize is sensitive to `priority`", {
 test_that("prioritize ignores other groups", {
   # styler: off
   matched <- tibble::tribble(
-    ~id, ~level, ~score, ~other_id, ~sector_ald,
-    "a",    "z",      1,         1,      "coal",
-    "a",    "a",      1,         2,      "coal",
-    "b",    "z",      1,         3,      "coal",
-    "b",    "a",      1,         4,      "coal",
+    ~id, ~level, ~score, ~other_id, ~sector_ald, ~sector,
+    "a",    "z",      1,         1,      "coal",  "coal",
+    "a",    "a",      1,         2,      "coal",  "coal",
+    "b",    "z",      1,         3,      "coal",  "coal",
+    "b",    "a",      1,         4,      "coal",  "coal",
   ) %>%
     group_by(other_id)
   # styler: on
@@ -170,11 +193,11 @@ test_that("prioritize ignores other groups", {
 test_that("prioritize previous preserves groups", {
   # styler: off
   matched <- tibble::tribble(
-    ~id, ~level, ~score, ~other_id, ~sector_ald,
-    "a",    "z",      1,         1, "automotive",
-    "a",    "a",      1,         2, "automotive",
-    "b",    "z",      1,         3, "automotive",
-    "b",    "a",      1,         4, "automotive",
+    ~id, ~level, ~score, ~other_id,  ~sector_ald,      ~sector,
+    "a",    "z",      1,         1, "automotive", "automotive",
+    "a",    "a",      1,         2, "automotive", "automotive",
+    "b",    "z",      1,         3, "automotive", "automotive",
+    "b",    "a",      1,         4, "automotive", "automotive",
   ) %>%
     group_by(other_id, score)
   # styler: on

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -1,7 +1,21 @@
 library(dplyr)
 library(r2dii.dataraw)
 
-test_that("prioritize works with loanbook_demo and ald_demo", {
+test_that("prioritize w/ 2 identical rows except for sector_ald yields 2 rows", {
+  # Minimal data derived from
+  # loanbook_demo %>% filter(id_loan == "L162")
+  # styler: off
+  matched <- tibble::tribble(
+    ~id_loan,   ~id,             ~level, ~score,      ~sector,  ~sector_ald,
+      "L162", "UP1",  "ultimate_parent",      1, "automotive",   "shipping",
+      "L162", "UP1",  "ultimate_parent",      1, "automotive", "automotive",
+  )
+  # styler: on
+
+  expect_equal(nrow(prioritize(matched)), 2L)
+})
+
+test_that("prioritize w/ full demo datasets throws no error", {
   expect_error(
     loanbook_demo %>%
       slice(4:5) %>%


### PR DESCRIPTION
@jdhoffa, please confirm this is a bug.

The problem seems to be that `prioritize()` currently groups by `id` only. 

https://github.com/2DegreesInvesting/r2dii.match/blob/44f8df5d577e696c1c9bd9e9f17c929dc5485a0e/R/prioritize.R#L56

We may fix this bug by grouping by `sector_ald` too. But I wonder what other columns should we also group by?