### PR TITLE
Warn/err if some/all classifications are unknown

### DIFF
--- a/R/add_sector_and_borderline.R
+++ b/R/add_sector_and_borderline.R
@@ -61,28 +61,39 @@ check_classification <- function(data,
   all_unknown <- !any(data[[column]] %in% reference[[column]])
   known <- unique(reference[[column]])
   if (all_unknown) {
-    abort(
-      class = "all_sector_classification_is_unknown",
-      message = glue(
-        "Some `{column}` must be known, i.e. one of:
-        {collapse2(known)}"
-      )
-    )
+    abort_all_sector_classification_is_unknown(column, known)
   }
 
   unknown <- setdiff(unique(data[[column]]), reference[[column]])
   some_unknown <- !identical(unknown, character(0))
   if (some_unknown) {
-    warn(
-      class = "some_sector_classification_is_unknown",
-      message = glue(
-        "Some `{column}` are unknown:
-        {collapse2(unknown)}"
-      )
-    )
+    warn_some_sector_classification_is_unknown(column, unknown)
   }
 
   invisible(data)
+}
+
+abort_all_sector_classification_is_unknown <- function(column, known) {
+  abort(
+    class = "all_sector_classification_is_unknown",
+    message = glue(
+      "Some `{column}` must be known, i.e. one of:
+      {collapse2(known)}"
+    )
+  )
+
+  invisible(column)
+}
+warn_some_sector_classification_is_unknown <- function(column, unknown) {
+  warn(
+    class = "some_sector_classification_is_unknown",
+    message = glue(
+      "Some `{column}` are unknown:
+      {collapse2(unknown)}"
+    )
+  )
+
+  invisible(column)
 }
 
 collapse2 <- function(x, sep = ", ", last = " and ", width = 80) {

--- a/R/fake_lbk.R
+++ b/R/fake_lbk.R
@@ -48,7 +48,7 @@
 #' fake_ald(new = "a")
 #'
 #' # Support for trailing commas
-#' fake_matched(id = "a",)
+#' fake_matched(id = "a", )
 #' @noRd
 fake_lbk <- function(sector_classification_system = NULL,
                      id_ultimate_parent = NULL,
@@ -83,7 +83,6 @@ fake_ald <- function(name_company = NULL,
     alias_ald = alias_ald %||% "alpineknitsindiapvt ltd",
     ...
   )
-
 }
 
 #' See `fake_lbk()`
@@ -184,4 +183,3 @@ crucial_lbk <- function() {
 crucial_ald <- function() {
   c("name_company", "sector")
 }
-

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -22,13 +22,15 @@
 #' @examples
 #' library(dplyr)
 #'
+#' # styler: off
 #' matched <- tribble(
-#'   ~sector, ~sector_ald, ~score,  ~id,  ~level,
-#'   "coal",  "coal",      1,       "aa", "ultimate_parent",
-#'   "coal",  "coal",      1,       "aa", "direct_loantaker",
-#'   "coal",  "coal",      1,       "bb", "intermediate_parent",
-#'   "coal",  "coal",      1,       "bb", "ultimate_parent",
+#'   ~sector, ~sector_ald,  ~score, ~id,  ~level,
+#'   "coal",  "coal",       1,      "aa", "ultimate_parent",
+#'   "coal",  "coal",       1,      "aa", "direct_loantaker",
+#'   "coal",  "coal",       1,      "bb", "intermediate_parent",
+#'   "coal",  "coal",       1,      "bb", "ultimate_parent",
 #' )
+#' # styler: on
 #'
 #' prioritize_level(matched)
 #'

--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -33,13 +33,15 @@ This function ignores but preserves existing groups them.
 \examples{
 library(dplyr)
 
+# styler: off
 matched <- tribble(
-  ~sector, ~sector_ald, ~score,  ~id,  ~level,
-  "coal",  "coal",      1,       "aa", "ultimate_parent",
-  "coal",  "coal",      1,       "aa", "direct_loantaker",
-  "coal",  "coal",      1,       "bb", "intermediate_parent",
-  "coal",  "coal",      1,       "bb", "ultimate_parent",
+  ~sector, ~sector_ald,  ~score, ~id,  ~level,
+  "coal",  "coal",       1,      "aa", "ultimate_parent",
+  "coal",  "coal",       1,      "aa", "direct_loantaker",
+  "coal",  "coal",       1,      "bb", "intermediate_parent",
+  "coal",  "coal",       1,      "bb", "ultimate_parent",
 )
+# styler: on
 
 prioritize_level(matched)
 

--- a/tests/testthat/output/match_name-sector_classification_is_unknown.txt
+++ b/tests/testthat/output/match_name-sector_classification_is_unknown.txt
@@ -1,0 +1,24 @@
+
+Error
+=====
+
+> match_name(all_bad_code, fake_ald())
+Error: Some `sector_classification_direct_loantaker` must be known, i.e. one of:
+A, 1, 11, 111, 112, 113, 114, 115, 116, 119, 12, 121, 122, 123, 124, 125, 126...
+
+> match_name(all_bad_system, fake_ald())
+Error: Some `sector_classification_system` must be known, i.e. one of:
+ISIC, NACE and NAICS
+
+
+Warning
+=======
+
+> invisible(match_name(some_bad_code, fake_ald()))
+Warning: Some `sector_classification_direct_loantaker` are unknown:
+-999
+
+> invisible(match_name(some_bad_system, fake_ald()))
+Warning: Some `sector_classification_system` are unknown:
+bad
+

--- a/tests/testthat/test-add_sector_and_borderline.R
+++ b/tests/testthat/test-add_sector_and_borderline.R
@@ -1,58 +1,55 @@
-# add_sector_and_borderline() needs r2dii.dataraw in the search() path
 library(r2dii.dataraw)
 
 test_that("add_sector_and_borderline()$borderline is of type logical", {
-  out <- add_sector_and_borderline(r2dii.dataraw::loanbook_demo)
-  expect_is(out$borderline, "logical")
+  expect_is(
+    add_sector_and_borderline(loanbook_demo)$borderline,
+    "logical"
+  )
 })
 
 test_that("add_sector_and_borderline outputs known output", {
-  out <- add_sector_and_borderline(r2dii.dataraw::loanbook_demo)
-  expect_known_output(out, "ref-add_sector_and_borderline", update = FALSE)
+  expect_known_output(
+    add_sector_and_borderline(loanbook_demo),
+    "ref-add_sector_and_borderline",
+    update = FALSE
+  )
 })
 
 test_that("add_sector_and_borderline returns a tibble dataframe", {
-  out <- add_sector_and_borderline(r2dii.dataraw::loanbook_demo)
-  expect_is(out, "tbl_df")
+  expect_is(
+    add_sector_and_borderline(loanbook_demo),
+    "tbl_df"
+  )
 })
 
 test_that("add_sector_and_borderline with wrong input errs gracefully", {
-  rename_crucial_column <- function(data, x) {
-    dplyr::rename(data, bad = x)
-  }
-  lbk <- r2dii.dataraw::loanbook_demo
-
-  lbk_missing_sector_classification_system <-
-    rename_crucial_column(lbk, "sector_classification_system")
   expect_error(
-    add_sector_and_borderline(lbk_missing_sector_classification_system),
+    add_sector_and_borderline(
+      select(loanbook_demo, -sector_classification_system)
+    ),
     "must have.*sector_classification_system"
   )
 
-  lbk_missing_sector_classification_direct_loantaker <-
-    rename_crucial_column(lbk, "sector_classification_direct_loantaker")
   expect_error(
-    add_sector_and_borderline(lbk_missing_sector_classification_direct_loantaker),
+    add_sector_and_borderline(
+      select(loanbook_demo, -sector_classification_direct_loantaker)
+    ),
     "must have.*sector_classification_direct_loantaker"
   )
 })
 
 test_that("add_sector_and_borderline adds two columns: `sector` and `borderline`", {
-  input <- r2dii.dataraw::loanbook_demo
-  expect_false(has_name(input, "sector"))
-  expect_false(has_name(input, "borderline"))
+  expect_false(has_name(loanbook_demo, "sector"))
+  expect_false(has_name(loanbook_demo, "borderline"))
 
-  output <- add_sector_and_borderline(input)
-  new_columns <- sort(setdiff(names(output), names(input)))
+  out <- add_sector_and_borderline(loanbook_demo)
+  new_columns <- sort(setdiff(names(out), names(loanbook_demo)))
   expect_equal(
     new_columns, c("borderline", "sector")
   )
 })
 
 test_that("add_sector_and_borderline added columns return acceptable values", {
-  input <- r2dii.dataraw::loanbook_demo
-  output <- add_sector_and_borderline(input)
-
   acceptable_sectors <- c(
     "automotive",
     "aviation",
@@ -67,38 +64,29 @@ test_that("add_sector_and_borderline added columns return acceptable values", {
   )
 
   expect_true(
-    all(output$sector %in% acceptable_sectors)
+    all(
+      add_sector_and_borderline(loanbook_demo)$sector %in% acceptable_sectors
+    )
   )
 })
 
 test_that("add_sector_and_borderline preserves typeof() input columns", {
-  input <- r2dii.dataraw::loanbook_demo
-  output <- add_sector_and_borderline(input)
+  out <- add_sector_and_borderline(loanbook_demo)
 
   expect_equal(
-    purrr::map_chr(input, typeof),
-    purrr::map_chr(output[names(input)], typeof),
+    purrr::map_chr(loanbook_demo, typeof),
+    purrr::map_chr(out[names(loanbook_demo)], typeof),
   )
 })
 
 test_that("add_sector_and_borderline outputs no missing value of `sector`", {
-  out <- add_sector_and_borderline(r2dii.dataraw::loanbook_demo)
+  out <- add_sector_and_borderline(loanbook_demo)
   expect_false(any(is.na(out$sector)))
 })
 
 test_that("add_sector_and_borderline outputs no missing value of `borderline`", {
-  out <- add_sector_and_borderline(r2dii.dataraw::loanbook_demo)
+  out <- add_sector_and_borderline(loanbook_demo)
   expect_false(any(is.na(out$borderline)))
-})
-
-test_that("add_sector_and_borderline with bad sector code system errs gracefully", {
-  bad_classification <- r2dii.dataraw::loanbook_demo %>%
-    mutate(sector_classification_system = "BAD_CLASSIFICATION")
-
-  expect_error(
-    add_sector_and_borderline(bad_classification),
-    "must use 2dii.*sector"
-  )
 })
 
 test_that("check_is_attached works as expected", {

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -82,7 +82,8 @@ test_that("w/ mismatching sector_classification and `by_sector = TRUE` yields
     out <- match_name(
       fake_lbk(sector_classification_direct_loantaker = code_for_sector_power),
       fake_ald(sector = sector_not_power),
-      by_sector = TRUE),
+      by_sector = TRUE
+    ),
     "no match"
   )
   expect_equal(nrow(out), 0L)
@@ -421,7 +422,8 @@ test_that("warns/errors if some/all system classification is unknown", {
   )
 
   verify_output(
-    test_path("output", "match_name-sector_classification_is_unknown.txt"), {
+    test_path("output", "match_name-sector_classification_is_unknown.txt"),
+    {
       "# Error"
       match_name(all_bad_code, fake_ald())
 
@@ -431,5 +433,6 @@ test_that("warns/errors if some/all system classification is unknown", {
       invisible(match_name(some_bad_code, fake_ald()))
 
       invisible(match_name(some_bad_system, fake_ald()))
-    })
+    }
+  )
 })

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -1,7 +1,7 @@
 library(dplyr)
 library(r2dii.dataraw)
 
-test_that("match_name with non-NA only at intermediate level yields matches at
+test_that("w/ non-NA only at intermediate level yields matches at
           only at intermediate level only", {
   lbk <- tibble(
     id_intermediate_parent_999 = "IP8",
@@ -27,7 +27,7 @@ test_that("match_name with non-NA only at intermediate level yields matches at
   expect_equal(out$level, "intermediate_parent_999")
 })
 
-test_that("match_name w/ missing values at all levels outputs 0-row", {
+test_that("w/ missing values at all levels outputs 0-row", {
   lbk <- tibble(
     id_direct_loantaker = NA_character_,
     name_direct_loantaker = NA_character_,
@@ -47,8 +47,7 @@ test_that("match_name w/ missing values at all levels outputs 0-row", {
   expect_equal(nrow(out), 0L)
 })
 
-test_that("match_name w/ 1 lbk row matching 1 ald company in 2 sectors yields
-          2 rows -- one per ald-sector", {
+test_that("w/ 1 lbk row matching 1 ald company in 2 sectors outputs 2 rows", {
   sector_ald <- c("automotive", "shipping")
 
   lbk <- tibble(
@@ -73,45 +72,9 @@ test_that("match_name w/ 1 lbk row matching 1 ald company in 2 sectors yields
   expect_equal(out$sector_ald, sector_ald)
 })
 
-test_that("match_name w/ bad sector_classification_system errors gracefully", {
-  expect_error(
-    match_name(
-      fake_lbk(sector_classification_system = "bad"),
-      fake_ald()
-    ),
-    "must use.*code system"
-  )
-})
-
-test_that("match_name with non existing sector code just warns '*.no match'", {
-  code_does_not_exist <- -9999L
-  code <- suppressWarnings(sort(as.integer(sector_clasiffication_df()$code)))
-  expect_false(any(code == code_does_not_exist))
-
-  expect_warning(
-    match_name(
-      fake_lbk(sector_classification_direct_loantaker = code_does_not_exist),
-      fake_ald()
-    ),
-    "no match"
-  )
-})
-
-test_that("match_name with sector 'not in scope' warns '*.no match'", {
-  sector_not_in_scope <- 1L
-
-  expect_warning(
-    match_name(
-      fake_lbk(sector_classification_direct_loantaker = sector_not_in_scope),
-      fake_ald()
-    ),
-    "no match"
-  )
-})
-
-test_that("match_name with mismatching sector_classification and
-          `by_sector = TRUE` yields no match", {
-  # Lookup code to sectors via sector_clasiffication_df()$code
+test_that("w/ mismatching sector_classification and `by_sector = TRUE` yields
+          no match", {
+  # Lookup code to sectors via sector_classification_df()$code
   code_for_sector_power <- 27
   sector_not_power <- "coal"
 
@@ -125,9 +88,9 @@ test_that("match_name with mismatching sector_classification and
   expect_equal(nrow(out), 0L)
 })
 
-test_that("match_name with mismatching sector_classification and
-          `by_sector = FALSE` yields a match", {
-  # Lookup code to sectors via sector_clasiffication_df()$code
+test_that("w/ mismatching sector_classification and `by_sector = FALSE` yields
+          a match", {
+  # Lookup code to sectors via sector_classification_df()$code
   code_for_sector_power <- 27
   sector_not_power <- "coal"
 
@@ -139,7 +102,7 @@ test_that("match_name with mismatching sector_classification and
   expect_equal(nrow(out), 1L)
 })
 
-test_that("match_name w/ row 1 of loanbook and crucial cols yields expected", {
+test_that("w/ row 1 of loanbook and crucial cols yields expected", {
   expected <- tibble(
     id_ultimate_parent = "UP15",
     name_ultimate_parent = "Alpine Knits India Pvt. Limited",
@@ -205,19 +168,19 @@ expected_names_of_match_name_with_loanbook_demo <- c(
   "source"
 )
 
-test_that("match_name w/ 1 row of full loanbook_demo yields expected names", {
+test_that("w/ 1 row of full loanbook_demo yields expected names", {
   out <- match_name(slice(loanbook_demo, 1L), fake_ald())
   expect_named(out, expected_names_of_match_name_with_loanbook_demo)
 })
 
-test_that("match_name takes unprepared loanbook and ald datasets", {
+test_that("takes unprepared loanbook and ald datasets", {
   expect_error(
     match_name(slice(loanbook_demo, 1), ald_demo),
     NA
   )
 })
 
-test_that("match_name w/ loanbook that matches nothing, yields expected", {
+test_that("w/ loanbook that matches nothing, yields expected", {
   # Matches cero row ...
   lbk2 <- slice(loanbook_demo, 2)
   expect_warning(
@@ -232,7 +195,7 @@ test_that("match_name w/ loanbook that matches nothing, yields expected", {
   )
 })
 
-test_that("match_name w/ 2 lbk rows matching 2 ald rows, yields expected names", {
+test_that("w/ 2 lbk rows matching 2 ald rows, yields expected names", {
   # Slice 5 once was problematic (#85)
   lbk45 <- slice(loanbook_demo, 4:5)
   expect_named(
@@ -241,8 +204,7 @@ test_that("match_name w/ 2 lbk rows matching 2 ald rows, yields expected names",
   )
 })
 
-test_that("match_name w/ 1 lbk row matching ultimate, yields expected names", {
-  # Slice 1 used to fail due to poorly handled levels
+test_that("w/ 1 lbk row matching ultimate, yields expected names", {
   lbk1 <- slice(loanbook_demo, 1)
 
   expect_named(
@@ -251,14 +213,14 @@ test_that("match_name w/ 1 lbk row matching ultimate, yields expected names", {
   )
 })
 
-test_that("match_name takes `min_score`", {
+test_that("takes `min_score`", {
   expect_error(
     match_name(slice(loanbook_demo, 1), ald_demo, min_score = 0.5),
     NA
   )
 })
 
-test_that("match_name takes `by_sector`", {
+test_that("takes `by_sector`", {
   expect_false(
     identical(
       match_name(slice(loanbook_demo, 4:15), ald_demo, by_sector = TRUE),
@@ -267,7 +229,7 @@ test_that("match_name takes `by_sector`", {
   )
 })
 
-test_that("match_name takes `method`", {
+test_that("takes `method`", {
   expect_false(
     identical(
       match_name(slice(loanbook_demo, 4:15), ald_demo, method = "jw"),
@@ -276,7 +238,7 @@ test_that("match_name takes `method`", {
   )
 })
 
-test_that("match_name takes `p`", {
+test_that("takes `p`", {
   lbk45 <- slice(loanbook_demo, 4:5) # slice(., 1) seems insensitive to `p`
 
   expect_false(
@@ -287,7 +249,7 @@ test_that("match_name takes `p`", {
   )
 })
 
-test_that("match_name takes `overwrite`", {
+test_that("takes `overwrite`", {
   expect_false(
     identical(
       match_name(slice(loanbook_demo, 4:25), ald_demo, overwrite = NULL),
@@ -296,7 +258,7 @@ test_that("match_name takes `overwrite`", {
   )
 })
 
-test_that("match_name recovers `sector_lbk`", {
+test_that("recovers `sector_lbk`", {
   expect_true(
     rlang::has_name(
       match_name(slice(loanbook_demo, 1), ald_demo),
@@ -305,25 +267,25 @@ test_that("match_name recovers `sector_lbk`", {
   )
 })
 
-test_that("match_name recovers `sector_ald`", {
+test_that("recovers `sector_ald`", {
   expect_true(
     rlang::has_name(match_name(loanbook_demo, ald_demo), "sector_ald")
   )
 })
 
-test_that("match_name outputs name from loanbook, not name.y (bug fix)", {
+test_that("outputs name from loanbook, not name.y (bug fix)", {
   out <- match_name(slice(loanbook_demo, 1), ald_demo)
   expect_false(has_name(out, "name.y"))
 })
 
-test_that("match_name works with `min_score = 0` (bug fix)", {
+test_that("works with `min_score = 0` (bug fix)", {
   expect_error(
     match_name(slice(loanbook_demo, 1), ald_demo, min_score = 0),
     NA
   )
 })
 
-test_that("match_name outputs only perfect matches if any (#40 @2diiKlaus)", {
+test_that("outputs only perfect matches if any (#40 @2diiKlaus)", {
   this_name <- "Nanaimo Forest Products Ltd."
   this_alias <- to_alias(this_name)
   this_lbk <- loanbook_demo %>%
@@ -369,20 +331,20 @@ test_that("match_name()$level lacks prefix 'name_' suffix '_lbk'", {
   )
 })
 
-test_that("match_name preserves groups", {
+test_that("preserves groups", {
   grouped_loanbook <- slice(loanbook_demo, 1) %>%
     group_by(id_loan)
 
   expect_true(is_grouped_df(match_name(grouped_loanbook, ald_demo)))
 })
 
-test_that("match_name outputs id consistent with level", {
+test_that("outputs id consistent with level", {
   out <- slice(loanbook_demo, 5) %>% match_name(ald_demo)
   expect_equal(out$level, c("ultimate_parent", "direct_loantaker"))
   expect_equal(out$id, c("UP1", "DL1"))
 })
 
-test_that("match_name no longer yiels all NAs in lbk columns (#85 @jdhoffa)", {
+test_that("no longer yiels all NAs in lbk columns (#85 @jdhoffa)", {
   out <- match_name(loanbook_demo, ald_demo)
   out_lbk_cols <- out %>%
     select(
@@ -399,7 +361,7 @@ test_that("match_name no longer yiels all NAs in lbk columns (#85 @jdhoffa)", {
   expect_false(all_lbk_columns_contain_na_exclusively)
 })
 
-test_that("match_name handles any number of intermediate_parent columns (#84)", {
+test_that("handles any number of intermediate_parent columns (#84)", {
   # name_level is identical for all levels. I expect them all in the output
   name_level <- "Alpine Knits India Pvt. Limited"
 
@@ -426,4 +388,48 @@ test_that("match_name handles any number of intermediate_parent columns (#84)", 
 
   has_intermediate_parent <- any(grepl("intermediate_parent_1", output_levels))
   expect_true(has_intermediate_parent)
+})
+
+test_that("warns/errors if some/all system classification is unknown", {
+  some_bad_system <- fake_lbk(sector_classification_system = c("NACE", "bad"))
+
+  expect_warning(
+    class = "some_sector_classification_is_unknown",
+    match_name(some_bad_system, fake_ald())
+  )
+
+  all_bad_system <- fake_lbk(sector_classification_system = c("bad", "bad"))
+
+  expect_error(
+    class = "all_sector_classification_is_unknown",
+    match_name(all_bad_system, fake_ald())
+  )
+
+  bad <- -999
+  some_bad_code <- fake_lbk(sector_classification_direct_loantaker = c(35, bad))
+
+  expect_warning(
+    class = "some_sector_classification_is_unknown",
+    match_name(some_bad_code, fake_ald()),
+  )
+
+  all_bad_code <- fake_lbk(sector_classification_direct_loantaker = c(bad, bad))
+
+  expect_error(
+    class = "all_sector_classification_is_unknown",
+    match_name(all_bad_code, fake_ald()),
+  )
+
+  verify_output(
+    test_path("output", "match_name-sector_classification_is_unknown.txt"), {
+      "# Error"
+      match_name(all_bad_code, fake_ald())
+
+      match_name(all_bad_system, fake_ald())
+
+      "# Warning"
+      invisible(match_name(some_bad_code, fake_ald()))
+
+      invisible(match_name(some_bad_system, fake_ald()))
+    })
 })

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -76,7 +76,7 @@ test_that("prioritize picks the highetst level per loan", {
 
   expect_equal(
     prioritize(matched)$level,
-    c("direct_loantaker", "intermediate_parent")  # **
+    c("direct_loantaker", "intermediate_parent") # **
   )
 })
 
@@ -117,7 +117,7 @@ test_that("prioritize ignores existing groups", {
 
   expect_equal(
     prioritize(matched, priority = "z")$level,
-    c("z", "z")  # **
+    c("z", "z") # **
   )
 })
 


### PR DESCRIPTION
Closes #103

* Remove duplicated tests
* Classify error/warning
* Remove redunant fun_name context from test_that("fun_name ...
* Verify output
* Remove hint which seems uninformative