### PR TITLE
prioritize() output is independent of row-order

### DIFF
--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -185,3 +185,20 @@ test_that("w/ id_loan at level direct* & ultimate* picks only direct* (#106)", {
   matched <- fake_matched(level = c("ultimate_parent", "direct_loantaker"))
   expect_identical(prioritize(matched)$level, "direct_loantaker")
 })
+
+test_that("output is independent from the row-order of the input", {
+  matched_direct <- tibble::tribble(
+    ~id_loan,   ~id,             ~level, ~score,      ~sector,  ~sector_ald,
+    "A",   "D", "direct_loantaker",      1, "automotive", "automotive",
+    "A",   "U",  "ultimate_parent",      1, "automotive", "automotive",
+    "B",   "U",  "ultimate_parent",      1, "automotive", "automotive",
+  )
+
+  matched_invert <- dplyr::arrange(matched_direct, desc(id_loan))
+
+  testthat::expect_equal(
+    prioritize(matched_direct)$id_loan,
+    prioritize(matched_invert)$id_loan
+  )
+
+})


### PR DESCRIPTION
Closes #113.

The fix was introduced in the previous commit. As a nice side
effect, this issue is also solved. Here I add a test to formalize
and record the fix.