### PR TITLE
Don't error on warning in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: R
 sudo: false
 cache: packages
 latex: false
+warnings_are_errors: false
 
 matrix:
   include:


### PR DESCRIPTION
With rdevel and `warnings_are_errors: true`, builds error with rdevel:

![](https://i.imgur.com/BO4ZYZ1.png)


The problem seems to be that rdevel takes too long to build and check, to the point it throws a warning. And that warning is converted to an error (because by default `warnings_are_errors: true`).

With `warnings_are_errors: false` I expect builds to pass.
