### PR TITLE
prioritize() errors with bad data (#114)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -15,3 +15,5 @@ extract_level_names <- function(data, prefix) {
 level <- function() {
   c("direct", "intermediate", "ultimate")
 }
+
+commas <- function(...) paste0(..., collapse = ", ")

--- a/tests/testthat/output/prioritize-duplicated_score1_by_id_loan_by_level.txt
+++ b/tests/testthat/output/prioritize-duplicated_score1_by_id_loan_by_level.txt
@@ -1,0 +1,5 @@
+> prioritize(invalid)
+Error: `data` where `score` is `1` must be unique by `id_loan` by `level`.
+Duplicated rows: 2.
+Have you ensured that only one ald-name per loanbook-name is set to `1`?
+


### PR DESCRIPTION
Closes #114

Bad data: where score=1 and values by id_loan+level are duplicated.
* Reuse fake_match()
* New internal check_duplicated_score1_by_id_loan_by_level()
* Verify useful error message.
* Off-topic, removed "prioritize" from all instances of `test_that("prioritize...` because it's redundant with the file name (tests/testthat/prioritize.R) which already appears in `devtools::test()`.

Thanks @jdhoffa