### PR TITLE
Don't depend on development versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Imports:
     glue,
     magrittr,
     purrr,
-    r2dii.utils (>= 0.0.0.9001),
+    r2dii.utils,
     rlang,
     stats,
     stringdist,
@@ -59,7 +59,7 @@ Imports:
     tidyselect
 Suggests: 
     covr,
-    r2dii.dataraw (>= 0.0.2.9000),
+    r2dii.dataraw,
     readr,
     rmarkdown,
     testthat (>= 2.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Suggests:
     covr,
     r2dii.dataraw,
     readr,
+    remotes,
     rmarkdown,
     testthat (>= 2.1.0)
 Remotes: 

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -56,6 +56,8 @@
 #'    "remotes::install_github('2degreesinvesting/r2dii.dataraw')"
 #'  )
 #' }
+#' # r2dii.dataraw is changing rapidly; ensure you have the latest version
+#' remotes::update_packages("r2dii.dataraw", upgrade = "ask")
 #' library(r2dii.dataraw)
 #' library(dplyr)
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,6 +42,8 @@ devtools::install_github("2DegreesInvesting/r2dii.match")
 
 ```{r}
 library(r2dii.match)
+# r2dii.dataraw is changing rapidly; ensure you have the latest version
+remotes::update_packages("r2dii.dataraw", upgrade = "ask")
 library(r2dii.dataraw)
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ devtools::install_github("2DegreesInvesting/r2dii.match")
 
 ``` r
 library(r2dii.match)
+# r2dii.dataraw is changing rapidly; ensure you have the latest version
+remotes::update_packages("r2dii.dataraw", upgrade = "ask")
 library(r2dii.dataraw)
 #> Loading required package: r2dii.utils
 ```
@@ -115,7 +117,7 @@ prioritize(match_result)
 #> #   score <dbl>, source <chr>
 ```
 
-The result is a dataset, with identical columns to the input loanbook,
+The result is a dataset with identical columns to the input loanbook,
 and added columns bridging all matched loans to their ald counterpart.
 
 For a more detailed walkthrough of the functionality [Get

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -5,6 +5,7 @@ counterparty
 csv
 dataraw
 dii
+dplyr
 funder
 https
 Jaro
@@ -15,9 +16,9 @@ Loanbook
 loantaker
 ORCID
 quosure
+readr
 rstudio
 stringdist
 tibble
-tidyverse
 walkthrough
 Winkler

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -93,6 +93,8 @@ if (!requireNamespace("r2dii.dataraw", quietly = TRUE)) {
    "remotes::install_github('2degreesinvesting/r2dii.dataraw')"
  )
 }
+# r2dii.dataraw is changing rapidly; ensure you have the latest version
+remotes::update_packages("r2dii.dataraw", upgrade = "ask")
 library(r2dii.dataraw)
 library(dplyr)
 

--- a/vignettes/r2dii.match.Rmd
+++ b/vignettes/r2dii.match.Rmd
@@ -17,6 +17,9 @@ We use the package r2dii.match to access the most important functions you'll lea
 
 ```{r}
 library(r2dii.match)
+
+# r2dii.dataraw is changing rapidly; ensure you have the latest version
+remotes::update_packages("r2dii.dataraw", upgrade = "ask")
 library(r2dii.dataraw)
 library(dplyr)
 library(readr)


### PR DESCRIPTION
Closes #150 

Asking users to use latest versions of r2dii packages seems like a good idea
but right now none of these packages have been released so asking for a
specific development version seems to cause more harm than good. (Users may
get an error even if their current version of r2dii would work just fine;
developers need to update the devel version in all reverse dependencies every
time they increment the devel version number). This problem was discussed by
@cjyetman in a ds-incubator meetup and I now see it expressed.

I therefore relax this requirement, and no longer ask for a specific devel
version number. Once we have a released version (even if just a GitHub
release) I'm happy to require that version explicitly.

Thanks @cjyetman