### PR TITLE
Don't pipe return() (#152)

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -100,9 +100,10 @@ match_name <- function(loanbook,
   no_match <- identical(nrow(matched), 0L)
   if (no_match) {
     warning("Found no match.", call. = FALSE)
-    named_tibble(names = minimum_names_of_match_name(loanbook)) %>%
+    out <- named_tibble(names = minimum_names_of_match_name(loanbook)) %>%
       unsuffix_and_regroup(old_groups) %>%
-      return()
+      select(-.data$alias, -.data$alias_ald)
+    return(out)
   }
 
   preferred <- prefer_perfect_match_by(matched, .data$id_2dii)

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -198,6 +198,7 @@ test_that("w/ loanbook that matches nothing, yields expected", {
     out,
     expected_names_of_match_name_with_loanbook_demo
   )
+  expect_false(any(c("alias", "alias_ald") %in% names(out)))
 })
 
 test_that("w/ 2 lbk rows matching 2 ald rows, yields expected names", {


### PR DESCRIPTION
Closes #152

This also catched a bug, by which match_name() returned the columns
"alias" and "alias_ald", which are excluded since #131.

Thanks @cjyetman