### PR TITLE
Coerce level cols as characters

### DIFF
--- a/R/restructure_loanbook_for_matching.R
+++ b/R/restructure_loanbook_for_matching.R
@@ -182,9 +182,12 @@ identify_loans_by_level <- function(data) {
 }
 
 identify_loans_by_name <- function(data) {
+  cols <- extract_level_names(data, prefix = "name_")
+
   data %>%
+    purrr::modify_at(cols, as.character) %>%
     tidyr::pivot_longer(
-      cols = extract_level_names(data, prefix = "name_"),
+      cols = cols,
       names_to = "level2",
       names_prefix = "name_",
       values_to = "name"

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -510,3 +510,10 @@ test_that("w/ overwrite with missing names errors gracefully", {
     )
   )
 })
+
+test_that("with bad input errors gracefully", {
+  bad_loanbook <- loanbook_demo %>%
+    mutate(name_direct_loantaker = as.numeric(12))
+
+  expect_no_error(match_name(bad_loanbook, ald_demo))
+})


### PR DESCRIPTION
Closes #146

If level columns are not of type character, we now coerce them to
character. Compared to throwing an error this seems more reasonable
as it is clear that these columns should be characters, and any
type can be coerced to character -- hence we can do it
programatically on behalf of the user.

Thanks @jdhoffa