### PR TITLE
Replace sample_n() with slice_sample()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Description: These tools implement in R a fundamental part of
     is the first step to assess if a financial portfolio aligns with
     climate goals.
 License: GPL-3
-URL: https://2degreesinvesting.github.io/r2dii.match, 
+URL: https://2degreesinvesting.github.io/r2dii.match,
     https://github.com/2DegreesInvesting/r2dii.match
 BugReports: 
     https://github.com/2DegreesInvesting/r2dii.match/issues
@@ -49,7 +49,7 @@ Imports:
     magrittr,
     purrr,
     r2dii.data,
-    rlang,
+    rlang (>= 0.4.5.9000),
     stringdist,
     stringi,
     tibble,
@@ -60,10 +60,11 @@ Suggests:
     rmarkdown,
     spelling,
     testthat (>= 2.1.0)
+Remotes: 
+    r-lib/rlang,
+    tidyverse/dplyr
 Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
-Remotes:  
-    tidyverse/dplyr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ BugReports:
 Depends: 
     R (>= 3.4)
 Imports: 
-    dplyr,
+    dplyr (>= 0.8.99.9002),
     glue,
     magrittr,
     purrr,
@@ -65,3 +65,5 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
+Remotes:  
+    tidyverse/dplyr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Imports:
     stringi,
     tibble,
     tidyr,
-    tidyselect
+    tidyselect,
+    vctrs (>= 0.2.99.9011)
 Suggests: 
     covr,
     rmarkdown,
@@ -62,6 +63,7 @@ Suggests:
     testthat (>= 2.1.0)
 Remotes: 
     r-lib/rlang,
+    r-lib/vctrs,
     tidyverse/dplyr
 Encoding: UTF-8
 Language: en-US

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -56,7 +56,7 @@
 #' library(r2dii.data)
 #' library(dplyr)
 #'
-#' mini_loanbook <- sample_n(loanbook_demo, 10)
+#' mini_loanbook <- slice_sample(loanbook_demo, n = 10)
 #'
 #' match_name(mini_loanbook, ald_demo)
 #'

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -91,7 +91,7 @@ This function ignores but preserves existing groups.
 library(r2dii.data)
 library(dplyr)
 
-mini_loanbook <- sample_n(loanbook_demo, 10)
+mini_loanbook <- slice_sample(loanbook_demo, n = 10)
 
 match_name(mini_loanbook, ald_demo)
 


### PR DESCRIPTION
> sample_n() and sample_frac() have been superseded by
  slice_sample(). See ?sample_n for details about why,
  and for examples converting from old to new usage.
https://github.com/tidyverse/dplyr/blob/master/NEWS.md#superseded