### PR TITLE
Speed up

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.match (development version)
 
+* Lint.
+* `match_name()` now runs faster (#214).
+
 # r2dii.match 0.0.3
 
 * Enforce dplyr >= 0.8.5 (#216).

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -83,44 +83,38 @@ match_name <- function(loanbook,
   prep_ald <- restructure_ald_for_matching(ald)
 
   matched <- score_alias_similarity(
-    prep_lbk, prep_ald,
-    by_sector = by_sector,
-    method = method,
-    p = p
+    prep_lbk, prep_ald, by_sector = by_sector, method = method, p = p
   ) %>%
-    pick_min_score(min_score)
+    filter(.data$score >= min_score)
 
   no_match <- identical(nrow(matched), 0L)
   if (no_match) {
     rlang::warn("Found no match.")
+
     out <- named_tibble(names = minimum_names_of_match_name(loanbook)) %>%
       unsuffix_and_regroup(old_groups) %>%
-      select(-.data$alias, -.data$alias_ald)
+      select(-.data$alias, -.data$alias_ald) %>%
+      distinct()
+
     return(out)
   }
 
-  preferred <- prefer_perfect_match_by(matched, .data$id_2dii)
-
-  preferred %>%
+  matched %>%
+    prefer_perfect_match_by(.data$id_2dii) %>%
     restore_sector_name_ald(prep_ald, by_sector = by_sector) %>%
     # Restore columns from loanbook
     left_join(loanbook_rowid, by = "rowid") %>%
     mutate(rowid = NULL) %>%
     reorder_names_as_in_loanbook(loanbook_rowid) %>%
     unsuffix_and_regroup(old_groups) %>%
-    select(-.data$alias, -.data$alias_ald)
+    select(-.data$alias, -.data$alias_ald) %>%
+    distinct()
 }
 
 unsuffix_and_regroup <- function(data, old_groups) {
   data %>%
     rename(alias = .data$alias_lbk) %>%
     dplyr::group_by(!!!old_groups)
-}
-
-pick_min_score <- function(data, min_score) {
-  data %>%
-    filter(.data$score >= min_score) %>%
-    distinct()
 }
 
 named_tibble <- function(names) {

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -120,7 +120,7 @@ unsuffix_and_regroup <- function(data, old_groups) {
 pick_min_score <- function(data, min_score) {
   data %>%
     filter(.data$score >= min_score) %>%
-    unique()
+    distinct()
 }
 
 named_tibble <- function(names) {

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -83,7 +83,8 @@ match_name <- function(loanbook,
   prep_ald <- restructure_ald_for_matching(ald)
 
   matched <- score_alias_similarity(
-    prep_lbk, prep_ald, by_sector = by_sector, method = method, p = p
+    prep_lbk, prep_ald,
+    by_sector = by_sector, method = method, p = p
   ) %>%
     filter(.data$score >= min_score)
 

--- a/R/score_alias_similarity.R
+++ b/R/score_alias_similarity.R
@@ -39,13 +39,11 @@ score_alias_similarity <- function(loanbook,
 
   out <- left_join(out, loanbook, by = c("alias_lbk" = "alias"))
 
-  distinct(
-    mutate(
-      out,
-      score = score_string_similarity(
-        out$alias_lbk, out$alias_ald,
-        method = method, p = p
-      )
+  mutate(
+    out,
+    score = score_string_similarity(
+      out$alias_lbk, out$alias_ald,
+      method = method, p = p
     )
   )
 }

--- a/R/score_alias_similarity.R
+++ b/R/score_alias_similarity.R
@@ -39,7 +39,7 @@ score_alias_similarity <- function(loanbook,
 
   out <- left_join(out, loanbook, by = c("alias_lbk" = "alias"))
 
-  unique(
+  distinct(
     mutate(
       out,
       score = score_string_similarity(

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -7,8 +7,6 @@ counterparty
 csv
 dii
 dplyr
-EvgenyPetrovsky
-fpalandri
 funder
 georgeharris
 https
@@ -20,12 +18,11 @@ loanbook
 loantaker
 ORCID
 PACTA
-PACTA’
 quosure
 readr
 rstudio
 stringdist
 tibble
+vctrs
 vintented
-walkthrough
 Winkler

--- a/tests/testthat/output/match_name-overwrite_warning.txt
+++ b/tests/testthat/output/match_name-overwrite_warning.txt
@@ -1,4 +1,4 @@
-> match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo)
+> tibble::as_tibble(match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo))
 Warning: You should only overwrite a sector at the level of the 'direct
 loantaker' (DL). If you overwrite a sector at the level of the 'ultimate
 parent' (UP) you consequently overwrite all children of that sector,

--- a/tests/testthat/output/match_name-overwrite_warning.txt
+++ b/tests/testthat/output/match_name-overwrite_warning.txt
@@ -1,15 +1,17 @@
-> tibble::as_tibble(match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo))
+> as.data.frame(match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo))
 Warning: You should only overwrite a sector at the level of the 'direct
 loantaker' (DL). If you overwrite a sector at the level of the 'ultimate
 parent' (UP) you consequently overwrite all children of that sector,
 which most likely is a mistake.
 
-# A tibble: 1 x 14
-  sector_classifi~ id_ultimate_par~ name_ultimate_p~ id_direct_loant~
-  <chr>            <chr>            <chr>            <chr>           
-1 NACE             UP15             Alpine Knits In~ C294            
-# ... with 10 more variables: name_direct_loantaker <chr>,
-#   sector_classification_direct_loantaker <dbl>, id_2dii <chr>, level <chr>,
-#   sector <chr>, sector_ald <chr>, name <chr>, name_ald <chr>, score <dbl>,
-#   source <chr>
+  sector_classification_system id_ultimate_parent
+1                         NACE               UP15
+             name_ultimate_parent id_direct_loantaker
+1 Alpine Knits India Pvt. Limited                C294
+                name_direct_loantaker sector_classification_direct_loantaker
+1 Yuamen Xinneng Thermal Power Co Ltd                                   3511
+  id_2dii           level sector sector_ald                            name
+1     UP1 ultimate_parent  power      power Alpine Knits India Pvt. Limited
+                         name_ald score   source
+1 alpine knits india pvt. limited     1 loanbook
 

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -272,7 +272,9 @@ test_that("warns overwrite", {
 
   verify_output(
     test_path("output", "match_name-overwrite_warning.txt"),
-    match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo)
+    tibble::as_tibble(
+      match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo)
+    )
   )
 })
 

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -272,7 +272,7 @@ test_that("warns overwrite", {
 
   verify_output(
     test_path("output", "match_name-overwrite_warning.txt"),
-    tibble::as_tibble(
+    as.data.frame(
       match_name(fake_lbk(), fake_ald(), overwrite = overwrite_demo)
     )
   )

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -522,3 +522,9 @@ test_that("with name_intermediate but not id_intermediate throws an error", {
     match_name(fake_lbk(name_intermediate_parent = "a"), fake_ald())
   )
 })
+
+test_that("outputs unique rows", {
+  lbk <- loanbook_demo[1:3, ]
+  out <- match_name(rbind(lbk, lbk), ald_demo)
+  expect_false(anyDuplicated(out) > 0L)
+})

--- a/tests/testthat/test-score_alias_similarity.R
+++ b/tests/testthat/test-score_alias_similarity.R
@@ -132,17 +132,3 @@ test_that("score_alias_similarity w/ same `alias` in 2 sectors and
     tibble(alias_lbk = "a", alias_ald = "a", sector = c("A", "B"), score = 1)
   )
 })
-
-test_that("score_alias_similarity outputs unique rows", {
-  # Known problematic data
-  lbk <- loanbook_demo %>%
-    tibble::rowid_to_column() %>%
-    filter(name_direct_loantaker == "Tata Group")
-
-  out <- score_alias_similarity(
-    restructure_loanbook(lbk),
-    restructure_ald_for_matching(ald_demo)
-  )
-
-  expect_equal(nrow(out), nrow(unique(out)))
-})


### PR DESCRIPTION
This pr makes `match_name()` faster by replacing `unique()` with the faster `dplyr::distinct()` and by calling it as late as possible -- when the data is smaller. It relates to #214 but doesn't solve the problem. We need to manage datasets that may be much larger than what is currently possible.

On Ubuntu (see system information below):

* Crashed with loanbook file of size 50 MB and ald file of size 300 MB.

* Crashed with loanbook file of size 36 MB and ald file of size 200 MB.

* Passed with loanbook file of size 18 MB and ald file of size 100 MB:


``` r
library(tibble)
library(vroom)
library(r2dii.match)
library(r2dii.data)

fs::file_size("ll.csv")
#> 18M
ll <- vroom("ll.csv")
#> Rows: 154,224
#> Columns: 19
#> Delimiter: ","
#> chr [13]: id_loan, id_direct_loantaker, name_direct_loantaker, id_intermediate_parent_1, n...
#> dbl [ 3]: loan_size_outstanding, loan_size_credit_limit, sector_classification_direct_loan...
#> lgl [ 3]: name_project, lei_direct_loantaker, isin_direct_loantaker
#> 
#> Use `spec()` to retrieve the guessed column specification
#> Pass a specification to the `col_types` argument to quiet this message
ll
#> # A tibble: 154,224 x 19
#>    id_loan id_direct_loant… name_direct_loa… id_intermediate… name_intermedia…
#>    <chr>   <chr>            <chr>            <chr>            <chr>           
#>  1 L168    C199             Tarpan           <NA>             <NA>            
#>  2 L196    C314             Zhongxing        <NA>             <NA>            
#>  3 L43     C261             Yongcheng Coal … <NA>             <NA>            
#>  4 L55     C249             Yiyang Baoyuan … <NA>             <NA>            
#>  5 L257    C17              China Shenhua E… <NA>             <NA>            
#>  6 L182    C219             Wm Motor         <NA>             <NA>            
#>  7 L235    C308             Yunnan Shiping … <NA>             <NA>            
#>  8 L206    C18              Cimentos Forte   <NA>             <NA>            
#>  9 L21     C286             Ytl Power Inter… <NA>             <NA>            
#> 10 L131    C75              Han Ren Heavyli… <NA>             <NA>            
#> # … with 154,214 more rows, and 14 more variables: id_ultimate_parent <chr>,
#> #   name_ultimate_parent <chr>, loan_size_outstanding <dbl>,
#> #   loan_size_outstanding_currency <chr>, loan_size_credit_limit <dbl>,
#> #   loan_size_credit_limit_currency <chr>, sector_classification_system <chr>,
#> #   sector_classification_input_type <chr>,
#> #   sector_classification_direct_loantaker <dbl>, fi_type <chr>,
#> #   flag_project_finance_loan <chr>, name_project <lgl>,
#> #   lei_direct_loantaker <lgl>, isin_direct_loantaker <lgl>


fs::file_size("aa.csv")
#> 106M
aa <- vroom("aa.csv")
#> Rows: 833,664
#> Columns: 14
#> Delimiter: ","
#> chr [8]: name_company, sector, technology, production_unit, country_of_domicile, plant_l...
#> dbl [4]: year, production, emission_factor, number_of_assets
#> lgl [2]: is_ultimate_owner, is_ultimate_listed_owner
#> 
#> Use `spec()` to retrieve the guessed column specification
#> Pass a specification to the `col_types` argument to quiet this message
aa
#> # A tibble: 833,664 x 14
#>    name_company sector technology production_unit  year production
#>    <chr>        <chr>  <chr>      <chr>           <dbl>      <dbl>
#>  1 noe landes-… power  gascap     MW               2028     32222.
#>  2 aston martin autom… electric   cars produced    2008    249305.
#>  3 ypf sa       oil a… oil        GJ per day       2016   9247633.
#>  4 soco intern… oil a… gas        GJ per day       2022  39189039.
#>  5 man diesel … power  gascap     MW               2026     36519.
#>  6 russian fed… oil a… gas        GJ per day       2025   7080179.
#>  7 tata sons l… power  oilcap     MW               2035       675.
#>  8 airborne of… aviat… passenger  active planes    2018       761.
#>  9 toyota moto… power  renewable… MW               2024      6735.
#> 10 cercl minin… coal   coal       tons per year    2020  76315709.
#> # … with 833,654 more rows, and 8 more variables: emission_factor <dbl>,
#> #   country_of_domicile <chr>, plant_location <chr>, number_of_assets <dbl>,
#> #   is_ultimate_owner <lgl>, is_ultimate_listed_owner <lgl>,
#> #   ald_timestamp <chr>, ald_emission_factor_unit <chr>

system.time(out <- match_name(ll, aa))
#>    user  system elapsed 
#>  92.606   5.941  54.839

out
#> # A tibble: 502 x 27
#>    id_loan id_direct_loant… name_direct_loa… id_intermediate… name_intermedia…
#>    <chr>   <chr>            <chr>            <chr>            <chr>           
#>  1 L170    C203             Tesla Inc        <NA>             <NA>            
#>  2 L180    C217             Weichai Power C… <NA>             <NA>            
#>  3 L181    C218             Wheego           <NA>             <NA>            
#>  4 L195    C313             Zhengzhou Yuton… <NA>             <NA>            
#>  5 L174    C211             Tvr              <NA>             <NA>            
#>  6 L198    C317             Ziyang Nanjun    <NA>             <NA>            
#>  7 L193    C310             Zamyad           <NA>             <NA>            
#>  8 L165    C195             Sunwin Bus       <NA>             <NA>            
#>  9 L154    C171             Shandong Tangju… <NA>             <NA>            
#> 10 L164    C193             Subaru Corp      <NA>             <NA>            
#> # … with 492 more rows, and 22 more variables: id_ultimate_parent <chr>,
#> #   name_ultimate_parent <chr>, loan_size_outstanding <dbl>,
#> #   loan_size_outstanding_currency <chr>, loan_size_credit_limit <dbl>,
#> #   loan_size_credit_limit_currency <chr>, sector_classification_system <chr>,
#> #   sector_classification_input_type <chr>,
#> #   sector_classification_direct_loantaker <dbl>, fi_type <chr>,
#> #   flag_project_finance_loan <chr>, name_project <lgl>,
#> #   lei_direct_loantaker <lgl>, isin_direct_loantaker <lgl>, id_2dii <chr>,
#> #   level <chr>, sector <chr>, sector_ald <chr>, name <chr>, name_ald <chr>,
#> #   score <dbl>, source <chr>
```

<sup>Created on 2020-07-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.0.0 (2020-04-24)
#>  os       Ubuntu 18.04.4 LTS          
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language en_US:en                    
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       America/Chicago             
#>  date     2020-07-10                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date       lib source                         
#>  assertthat    0.2.1      2019-03-21 [1] CRAN (R 4.0.0)                 
#>  backports     1.1.8      2020-06-17 [1] CRAN (R 4.0.0)                 
#>  bit           1.1-15.2   2020-02-10 [1] CRAN (R 4.0.0)                 
#>  bit64         0.9-7      2017-05-08 [1] CRAN (R 4.0.0)                 
#>  callr         3.4.3      2020-03-28 [1] CRAN (R 4.0.0)                 
#>  cli           2.0.2      2020-02-28 [1] CRAN (R 4.0.0)                 
#>  crayon        1.3.4      2017-09-16 [1] CRAN (R 4.0.0)                 
#>  desc          1.2.0      2018-05-01 [1] CRAN (R 4.0.0)                 
#>  devtools      2.3.0      2020-04-10 [1] CRAN (R 4.0.0)                 
#>  digest        0.6.25     2020-02-23 [1] CRAN (R 4.0.0)                 
#>  dplyr         1.0.0      2020-05-29 [1] CRAN (R 4.0.0)                 
#>  ellipsis      0.3.1      2020-05-15 [1] CRAN (R 4.0.0)                 
#>  evaluate      0.14       2019-05-28 [1] CRAN (R 4.0.0)                 
#>  fansi         0.4.1      2020-01-08 [1] CRAN (R 4.0.0)                 
#>  fs            1.4.2      2020-06-30 [1] RSPM (R 4.0.2)                 
#>  generics      0.0.2      2018-11-29 [1] CRAN (R 4.0.0)                 
#>  glue          1.4.1      2020-05-13 [1] CRAN (R 4.0.0)                 
#>  highr         0.8        2019-03-20 [1] CRAN (R 4.0.0)                 
#>  htmltools     0.5.0      2020-06-16 [1] CRAN (R 4.0.0)                 
#>  knitr         1.29       2020-06-23 [1] RSPM (R 4.0.2)                 
#>  lifecycle     0.2.0      2020-03-06 [1] CRAN (R 4.0.0)                 
#>  magrittr      1.5        2014-11-22 [1] CRAN (R 4.0.0)                 
#>  memoise       1.1.0      2017-04-21 [1] CRAN (R 4.0.0)                 
#>  pillar        1.4.6      2020-07-10 [1] CRAN (R 4.0.0)                 
#>  pkgbuild      1.0.8      2020-05-07 [1] CRAN (R 4.0.0)                 
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.0.0)                 
#>  pkgload       1.1.0      2020-05-29 [1] CRAN (R 4.0.0)                 
#>  prettyunits   1.1.1      2020-01-24 [1] CRAN (R 4.0.0)                 
#>  processx      3.4.3      2020-07-05 [1] RSPM (R 4.0.2)                 
#>  ps            1.3.3      2020-05-08 [1] CRAN (R 4.0.0)                 
#>  purrr         0.3.4      2020-04-17 [1] CRAN (R 4.0.0)                 
#>  r2dii.data  * 0.1.1      2020-06-10 [1] CRAN (R 4.0.0)                 
#>  r2dii.match * 0.0.3.9000 2020-07-11 [1] local                          
#>  R6            2.4.1      2019-11-12 [1] CRAN (R 4.0.0)                 
#>  Rcpp          1.0.5      2020-07-06 [1] CRAN (R 4.0.0)                 
#>  remotes       2.1.1      2020-02-15 [1] CRAN (R 4.0.0)                 
#>  rlang         0.4.7      2020-07-09 [1] CRAN (R 4.0.0)                 
#>  rmarkdown     2.3        2020-06-18 [1] CRAN (R 4.0.0)                 
#>  rprojroot     1.3-2      2018-01-03 [1] CRAN (R 4.0.0)                 
#>  sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 4.0.0)                 
#>  stringdist    0.9.5.5    2019-10-21 [1] CRAN (R 4.0.0)                 
#>  stringi       1.4.6      2020-02-17 [1] CRAN (R 4.0.0)                 
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.0.0)                 
#>  testthat      2.3.2.9000 2020-05-29 [1] Github (r-lib/testthat@8396241)
#>  tibble      * 3.0.3      2020-07-10 [1] CRAN (R 4.0.0)                 
#>  tidyr         1.1.0      2020-05-20 [1] CRAN (R 4.0.0)                 
#>  tidyselect    1.1.0      2020-05-11 [1] CRAN (R 4.0.0)                 
#>  usethis       1.6.1.9000 2020-05-20 [1] Github (r-lib/usethis@0144ea1) 
#>  utf8          1.1.4      2018-05-24 [1] CRAN (R 4.0.0)                 
#>  vctrs         0.3.1      2020-06-14 [1] local                          
#>  vroom       * 1.2.1      2020-05-12 [1] CRAN (R 4.0.0)                 
#>  withr         2.2.0      2020-04-20 [1] CRAN (R 4.0.0)                 
#>  xfun          0.15       2020-06-21 [1] RSPM (R 4.0.1)                 
#>  yaml          2.2.1      2020-02-01 [1] CRAN (R 4.0.0)                 
#> 
#> [1] /home/mauro/R/x86_64-pc-linux-gnu-library/4.0
#> [2] /opt/R/4.0.0/lib/R/library
```

</details>