### PR TITLE
Simpler example

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -54,19 +54,15 @@
 #' @export
 #'
 #' @examples
-#' library(dplyr, warn.conflicts = FALSE)
 #' library(r2dii.data)
 #'
-#' mini_loanbook <- sample_n(loanbook_demo, 10)
-#' ald <- distinct(ald_demo, name_company, sector)
+#' # Small data for examples
+#' loanbook <- head(loanbook_demo, 50)
+#' ald <- head(ald_demo, 50)
 #'
-#' match_name(mini_loanbook, ald)
+#' match_name(loanbook, ald)
 #'
-#' match_name(
-#'   mini_loanbook, ald,
-#'   min_score = 0.9,
-#'   by_sector = TRUE
-#' )
+#' match_name(loanbook, ald, min_score = 0.9)
 match_name <- function(loanbook,
                        ald,
                        by_sector = TRUE,

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -89,19 +89,15 @@ This function ignores but preserves existing groups.
 }
 
 \examples{
-library(dplyr, warn.conflicts = FALSE)
 library(r2dii.data)
 
-mini_loanbook <- sample_n(loanbook_demo, 10)
-ald <- distinct(ald_demo, name_company, sector)
+# Small data for examples
+loanbook <- head(loanbook_demo, 50)
+ald <- head(ald_demo, 50)
 
-match_name(mini_loanbook, ald)
+match_name(loanbook, ald)
 
-match_name(
-  mini_loanbook, ald,
-  min_score = 0.9,
-  by_sector = TRUE
-)
+match_name(loanbook, ald, min_score = 0.9)
 }
 \seealso{
 Other user-oriented: 


### PR DESCRIPTION
As users reported memory issues, it seems reasonable to discourage
using the by_sector argument.

Also:

* Using smaller data so the example runs faster
* Replace dplyr::sample_n() with head() to keep things simple, and
  because sample_n() is superseded by slice_heas() but it seems too
  early to use slice_head()  -- it requires a too-new version of
  dplyr.