### PR TITLE
match_name() now errors with reserved columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 User-facing
 
+* `match_name()` now errores with a more informative message if `loanbook` has reserved columns -- `alias`, `rowid`, or `sector` (#233).
+
 * New `crucial_lbk()` helps select the minimum loanbook columns for `match_name()` to run (#236).
 
 * `match_name()` now runs faster and uses less memory (@georgeharris2deg #214).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 User-facing
 
-* `match_name()` now errores with a more informative message if `loanbook` has reserved columns -- `alias`, `rowid`, or `sector` (#233).
+* `match_name()` now errors with a more informative message if `loanbook` has reserved columns -- `alias`, `rowid`, or `sector` (#233).
 
 * New `crucial_lbk()` helps select the minimum loanbook columns for `match_name()` to run (#236).
 

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -93,6 +93,8 @@ match_name_impl <- function(loanbook,
                             overwrite = NULL) {
   old_groups <- dplyr::groups(loanbook)
   loanbook <- ungroup(loanbook)
+
+  abort_reserved_column(loanbook)
   loanbook_rowid <- tibble::rowid_to_column(loanbook)
 
   prep_lbk <- restructure_loanbook(loanbook_rowid, overwrite = overwrite)
@@ -155,6 +157,21 @@ match_name_impl <- function(loanbook,
   attr(matched, ".internal.selfref") <- NULL
 
   matched
+}
+
+abort_reserved_column <- function(data) {
+  reserved_chr <- c("alias", "rowid", "sector")
+  is_reserved <- names(data) %in% reserved_chr
+
+  if (any(is_reserved)) {
+    bad <- paste0(sort(names(data)[is_reserved]), collapse = ", ")
+    abort(
+      class = "reserved_column",
+      glue("`loanbook` can't have reserved columns:\n{bad}")
+    )
+  }
+
+  invisible(data)
 }
 
 empty_loanbook_tibble <- function(loanbook, old_groups) {

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -540,3 +540,40 @@ test_that("w/ duplicates in ald throws now error; instead remove duplicates", {
   expect_error(out <- match_name(fake_lbk(), dupl), NA)
   expect_equal(nrow(out), 1L)
 })
+
+test_that("throws an error if the `loanbook` has reserved columns", {
+  alias <- mutate(fake_lbk(), alias = "bla")
+  expect_error(
+    class = "reserved_column",
+    match_name(alias, fake_ald()),
+    regexp = "alias"
+  )
+
+  sector <- mutate(fake_lbk(), sector = "auto")
+  expect_error(
+    class = "reserved_column",
+    match_name(sector, fake_ald()),
+    regexp = "sector"
+  )
+
+  rowid <- mutate(fake_lbk(), rowid = 1L)
+  expect_error(
+    class = "reserved_column",
+    match_name(rowid, fake_ald()),
+    regexp = "rowid"
+  )
+
+  rowid_sector <- mutate(fake_lbk(), rowid = 1L, sector = "auto")
+  expect_error(
+    class = "reserved_column",
+    match_name(rowid_sector, fake_ald()),
+    regexp = "rowid.*sector"
+  )
+
+  sector_rowid <- mutate(fake_lbk(), sector = "auto", rowid = 1L)
+  expect_error(
+    class = "reserved_column",
+    match_name(sector_rowid, fake_ald()),
+    regexp = "rowid.*sector"
+  )
+})


### PR DESCRIPTION
@jdhoffa, this extends #233.

`match_name()` now errors with a more informative message if `loanbook` has reserved columns -- `sector`, `rowid`, or `alias`. If you agree, I would include this in the upcoming release.

``` r
devtools::load_all()
#> Loading r2dii.match

lbk <- mutate(
  fake_lbk(), 
  sector = "a", 
  alias = "a", 
  rowid = 1, 
  not_reserved = 1
)

match_name(lbk, fake_ald())
#> Error: `loanbook` can't have reserved columns:
#> alias, rowid, sector
```

<sup>Created on 2020-08-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>