### PR TITLE
Add matching coverage article

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -35,6 +35,11 @@ navbar:
   - text: "Reference"
     href: reference/index.html
 
+  - text: "Articles"
+  menu:
+  - text: "Calculating Matching Coverage"
+    href: articles/matching-coverage.html
+
   - text: "News"
     menu:
     - text: "Release notes"

--- a/vignettes/matching-coverage.Rmd
+++ b/vignettes/matching-coverage.Rmd
@@ -1,0 +1,191 @@
+---
+title: "Calculating Matching Coverage"
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+For a variety of reasons, it is extremely unlikely that you will be able to match 
+every loan in your loanbook to a company in the Asset-Level data. To begin with, 
+not every company is active in the sectors that 2DII focuses on. We refer to 
+companies operating outside of 2DII's sectoral scope as `not in scope`. 
+
+Even if the company does in  operate in an `in scope` sector, the asset-level 
+dataset may not have information about it. 
+
+To account for this, it is often useful to calculate a variety of loanbook 
+coverage statistics. There are two interesting ways of doing this:
+
+1. Calculate the portion of your loanbook covered by dollar value 
+    (i.e. using one of the `loan_size_*` columns).
+2. Count the number of companies matched
+
+## Setup
+
+First we will need to load up the useful packages:
+
+```{r}
+library(dplyr, warn.conflicts = FALSE)
+library(ggplot2)
+library(r2dii.data)
+library(r2dii.match)
+```
+
+We will use the `demo` datasets from `r2dii.data` for this example. Currently 
+`loanbook_demo` is not the most indicative of what actually happens in practice, 
+so we will massage it a bit to ensure that a couple of loans don't match:
+
+```{r}
+loanbook <- loanbook_demo %>% 
+  mutate(
+    name_ultimate_parent = ifelse(
+      id_loan == "L1", 
+      "unmatched company name",
+      name_ultimate_parent
+      ),
+    sector_classification_direct_loantaker = ifelse(
+      id_loan == "L2",
+      99,
+      sector_classification_direct_loantaker
+      )
+    )
+```
+
+We will then run the matching algorithm on this loanbook:
+
+```{r}
+match_result <- loanbook_demo %>% 
+    match_name(ald_demo) %>% 
+    prioritize()
+```
+
+Note that this `match_result` file will contain ONLY loans that were able to be 
+matched. To determine coverage, we need to go back to the original `loanbook` 
+file. We must determine the 2DII sectors of each loan, as dictated by the 
+`sector_classification_direct_loantaker` column:
+
+```{r}
+# TODO: maybe export this function?
+loanbook_with_sectors <- r2dii.match:::add_sector_and_borderline(loanbook)
+```
+
+We can join these two datasets together, to generate our `coverage` dataset:
+
+``` {r}
+coverage_data <- loanbook_with_sectors %>% 
+  left_join(match_result) %>% 
+  mutate(loan_size_outstanding = as.numeric(loan_size_outstanding),
+         loan_size_credit_limit = as.numeric(loan_size_credit_limit)) %>% 
+  mutate(
+    matched = case_when(
+      score == 1 ~ "Matched",
+      is.na(score) ~ "Not Matched",
+      TRUE ~ "Not Mached"
+      )
+    # sector = case_when(
+    #   borderline == TRUE & matched == "Not Matched" ~ "not in scope",
+    #   TRUE ~ sector
+    #   )
+    )
+  
+```
+
+## Calculating Coverage by Dollar Value
+
+From the `coverage` dataset, we can easily calculate the total loanbook coverage 
+by dollar value: 
+
+```{r}
+coverage_data %>% 
+  select(loan_size_outstanding, sector, matched) %>% 
+  group_by(matched) %>% 
+  summarize(loan_size_outstanding = sum(loan_size_outstanding)) %>% 
+  ggplot(aes(x = factor(0), y = loan_size_outstanding, fill = matched)) +
+  geom_bar(stat = "identity") +
+  scale_x_discrete(breaks = NULL) +
+  xlab(NULL)
+```
+
+Note, that this includes loans that were deemed `not in scope` for the analysis. 
+To calculate the total, in-scope, loanbook coverage: 
+
+```{r}
+coverage_data %>% 
+  filter(sector != "not in scope") %>% 
+  select(loan_size_outstanding, sector, matched) %>% 
+  group_by(matched) %>% 
+  summarize(loan_size_outstanding = sum(loan_size_outstanding)) %>% 
+  ggplot(aes(x = factor(0), y = loan_size_outstanding, fill = matched)) +
+  geom_bar(stat = "identity") +
+  scale_x_discrete(breaks = NULL) +
+  xlab(NULL)
+```
+
+You might like to break-down the plot by sector... : 
+
+```{r}
+coverage_data %>% 
+  select(loan_size_outstanding, sector, matched) %>% 
+  group_by(matched, sector) %>% 
+  summarize(loan_size_outstanding = sum(loan_size_outstanding)) %>% 
+  ggplot(aes(x = sector, y = loan_size_outstanding, fill = matched)) +
+  geom_bar(stat = "identity")
+```
+
+... or even further, by matching level:
+
+```{r}
+coverage_data %>% 
+  mutate(matched = case_when(
+    matched == "Matched" & level == "direct_loantaker" ~ "Matched DL",
+    matched == "Matched" & level == "intermediate_parent_1" ~ "Matched IP1",
+    matched == "Matched" & level == "ultimate_parent" ~ "Matched UP",
+    matched == "Not Matched" ~ "Not Matched"
+  )) %>% 
+  select(loan_size_outstanding, sector, matched) %>% 
+  group_by(matched, sector) %>% 
+  summarize(loan_size_outstanding = sum(loan_size_outstanding)) %>% 
+  ggplot(aes(x = sector, y = loan_size_outstanding, fill = matched)) +
+  geom_bar(stat = "identity")
+```
+
+## Coverage by Number of Companies in Loanbook
+You might also be interested in knowing how many companies in your loanbook were 
+matched. It probably makes most sense to do this at the `direct_loantaker` 
+level:
+
+``` {r}
+companies_matched <- coverage_data %>% 
+  select(name_direct_loantaker, sector, matched) %>% 
+  group_by(sector, matched) %>% 
+  summarize(no_companies = n_distinct(name_direct_loantaker))
+
+companies_matched %>% 
+  ggplot(aes(x = sector, y = no_companies, fill = matched)) +
+  geom_bar(stat = "identity")
+
+```
+
+## A Note on Sector Classifications and the `borderline` Flag
+There are a zoo of sector classification code systems out there. Some are 
+granular, some are not. Since we currently cover a particular portion of the 
+supply chain (in particular production), it is important we try to only match 
+the ALD with companies that are actually active in this portion of the supply 
+chain. 
+
+An issue arises when, for example, a company is classified in the "power 
+transmission" sector. In a perfect world, these companies would produce no 
+electricity, and we would not try to match them. In practice, however, we find 
+there is often overlap. For this reason, we introduced the `borderline` flag. 
+
+If a sector classification code maps perfectly to a 2DII sector (e.g. "Power 
+Production" -> "power"), then we set the `borderline` flag to `FALSE`. If the 
+match is not perfect (e.g. "Power Transmission" -> "power"), then we set the 
+`borderline` flag to `TRUE`. 
+
+In practice, if a company has a `borderline` of `TRUE` and IS matched, then 
+consider the company in scope. If it has a `borderline` of `TRUE` and ISN'T

--- a/vignettes/matching-coverage.Rmd
+++ b/vignettes/matching-coverage.Rmd
@@ -9,12 +9,14 @@ knitr::opts_chunk$set(
 )
 ```
 
-For a variety of reasons, it is extremely unlikely that you will be able to match 
-every loan in your loanbook to a company in the Asset-Level data. To begin with, 
-not every company is active in the sectors that 2DII focuses on. We refer to 
-companies operating outside of 2DII's sectoral scope as `not in scope`. 
+The purpose of this package is to allow you to easily match loans from your 
+loanbook to the companies in an arbitrary asset-level dataset. For a variety of 
+reasons, it is extremely unlikely that you will be able to match every loan in 
+your loanbook. To begin with, not every company is active in the sectors that 
+the analysis focuses on (i.e. `r unique(r2dii.data::ald_demo$sector)`) . We 
+refer to companies operating outside of 2DII's sectoral scope as `not in scope`. 
 
-Even if the company does in  operate in an `in scope` sector, the asset-level 
+Even if the company does operate in an `in scope` sector, the asset-level 
 dataset may not have information about it. 
 
 To account for this, it is often useful to calculate a variety of loanbook 
@@ -63,7 +65,7 @@ match_result <- loanbook_demo %>%
     prioritize()
 ```
 
-Note that this `match_result` file will contain ONLY loans that were able to be 
+Note that this `match_result` file will contain ONLY loans that were successfully 
 matched. To determine coverage, we need to go back to the original `loanbook` 
 file. We must determine the 2DII sectors of each loan, as dictated by the 
 `sector_classification_direct_loantaker` column:


### PR DESCRIPTION
I thought about it, and think this is actually something that deserves a little more than a blog post. It's pretty crucial for banks to be able to determine how much of their loanbook was covered, and it can get a little confusing with all the different `sector`, `sector_ald`, `borderline` etc. 

@maurolepore @georgeharris2deg @2diiKlaus could you please have a look at this and let me know what you think? 

Closes #262