### PR TITLE
Use 'release' mode

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,7 @@
 destination: docs
 
 development:
-  mode: devel
+  mode: release
 
 template:
   params:


### PR DESCRIPTION
Before I misread the meaning of 'devel' and 'release'.
I now understand we need 'release' to expose the
development version of the website on the main website,
i.e. the development version of the website gets built
into docs/.
