### PR TITLE
Allow sector borderline input (#326)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.match (development version)
 
+* `match_name` now accepts loanbook input with `sector` and `borderline` 
+  already defined (#326). 
 * Avoid failures due to changes in r2dii.data that are expected.
 
 # r2dii.match 0.0.6

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -146,7 +146,9 @@ match_name_impl <- function(loanbook,
 
   # Restore columns from loanbook
   setDT(loanbook_rowid)
-  matched <- loanbook_rowid[matched, on = "rowid"]
+  maybe_columns <- c("rowid", "sector", "borderline")
+  join_on <- intersect(maybe_columns, names(loanbook_rowid))
+  matched <- loanbook_rowid[matched, on = join_on]
   matched <- matched[, rowid := NULL]
   matched <- as_tibble(matched)
 

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -160,7 +160,7 @@ match_name_impl <- function(loanbook,
 }
 
 abort_reserved_column <- function(data) {
-  reserved_chr <- c("alias", "rowid", "sector")
+  reserved_chr <- c("alias", "rowid")
   is_reserved <- names(data) %in% reserved_chr
 
   if (any(is_reserved)) {

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -587,3 +587,11 @@ test_that("matches any case of ald$name_company, but preserves original case", {
   # The original uppercase is preserved
   expect_equal(upp$name_ald, "ALPINE KNITS")
 })
+
+test_that("allows for input data to have `sector` and `borderline`", {
+  loanbook <- fake_lbk() %>%
+    mutate(sector = "power", borderline = TRUE)
+
+  expect_success(match_name(loanbook, ald_demo))
+
+})

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -505,32 +505,11 @@ test_that("throws an error if the `loanbook` has reserved columns", {
     regexp = "alias"
   )
 
-  sector <- mutate(fake_lbk(), sector = "auto")
-  expect_error(
-    class = "reserved_column",
-    match_name(sector, fake_ald()),
-    regexp = "sector"
-  )
-
   rowid <- mutate(fake_lbk(), rowid = 1L)
   expect_error(
     class = "reserved_column",
     match_name(rowid, fake_ald()),
     regexp = "rowid"
-  )
-
-  rowid_sector <- mutate(fake_lbk(), rowid = 1L, sector = "auto")
-  expect_error(
-    class = "reserved_column",
-    match_name(rowid_sector, fake_ald()),
-    regexp = "rowid.*sector"
-  )
-
-  sector_rowid <- mutate(fake_lbk(), sector = "auto", rowid = 1L)
-  expect_error(
-    class = "reserved_column",
-    match_name(sector_rowid, fake_ald()),
-    regexp = "rowid.*sector"
   )
 })
 
@@ -592,6 +571,13 @@ test_that("allows for input data to have `sector` and `borderline`", {
   loanbook <- fake_lbk() %>%
     mutate(sector = "power", borderline = TRUE)
 
-  expect_success(match_name(loanbook, ald_demo))
+  out_usual <- match_name(fake_lbk(), fake_ald())
+
+  out <- match_name(loanbook, fake_ald())
+
+  expect_equal(out$sector, "power")
+  expect_equal(out$borderline, TRUE)
+  expect_equal(setdiff(names(out), names(out_usual)), character(0))
+
 
 })


### PR DESCRIPTION
`match_name` now accepts a `loanbook` object that may or may not have the `sector` and `borderline` defined. If defined, it will use these values, otherwise, it will join our proprietary sector classifications. 

A fun side-product of this is that users can now manually set the sectors!

Relates to 2DegreesInvesting/r2dii.analysis#227
Closes #326