### PR TITLE
New option allows reserved loanbook columns

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -160,7 +160,7 @@ match_name_impl <- function(loanbook,
 }
 
 allow_reserved_columns <- function() {
-  isTRUE(getOption("allow_reserved_columns"))
+  isTRUE(getOption("r2dii.match.allow_reserved_columns"))
 }
 
 abort_reserved_column <- function(data) {

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -94,7 +94,7 @@ match_name_impl <- function(loanbook,
   old_groups <- dplyr::groups(loanbook)
   loanbook <- ungroup(loanbook)
 
-  abort_reserved_column(loanbook)
+  if (!allow_reserved_columns()) abort_reserved_column(loanbook)
   loanbook_rowid <- tibble::rowid_to_column(loanbook)
 
   prep_lbk <- restructure_loanbook(loanbook_rowid, overwrite = overwrite)
@@ -157,6 +157,10 @@ match_name_impl <- function(loanbook,
   attr(matched, ".internal.selfref") <- NULL
 
   matched
+}
+
+allow_reserved_columns <- function() {
+  isTRUE(getOption("allow_reserved_columns"))
 }
 
 abort_reserved_column <- function(data) {

--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -39,12 +39,17 @@ matched \%>\%
 
 Compare, edit, and save the data manually:
 \itemize{
-\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google Sheets, etc.).
-\item Compare the columns \code{name} and \code{name_ald} manually to determine if the match is valid. Other information can be used in conjunction with just the names to ensure the two entities match (sector, internal information on the company structure, etc.)
+\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google
+Sheets, etc.).
+\item Compare the columns \code{name} and \code{name_ald} manually to determine if
+the match is valid. Other information can be used in conjunction
+with just the names to ensure the two entities match (sector,
+internal information on the company structure, etc.)
 \item Edit the data:
 \itemize{
 \item If you are happy with the match, set the \code{score} value to \code{1}.
-\item Otherwise set or leave the \code{score} value to anything other than \code{1}.
+\item Otherwise set or leave the \code{score} value to anything other than
+\code{1}.
 }
 \item Save the edited file as, say, \emph{valid_matches.csv}.
 }

--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -39,17 +39,12 @@ matched \%>\%
 
 Compare, edit, and save the data manually:
 \itemize{
-\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google
-Sheets, etc.).
-\item Compare the columns \code{name} and \code{name_ald} manually to determine if
-the match is valid. Other information can be used in conjunction
-with just the names to ensure the two entities match (sector,
-internal information on the company structure, etc.)
+\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google Sheets, etc.).
+\item Compare the columns \code{name} and \code{name_ald} manually to determine if the match is valid. Other information can be used in conjunction with just the names to ensure the two entities match (sector, internal information on the company structure, etc.)
 \item Edit the data:
 \itemize{
 \item If you are happy with the match, set the \code{score} value to \code{1}.
-\item Otherwise set or leave the \code{score} value to anything other than
-\code{1}.
+\item Otherwise set or leave the \code{score} value to anything other than \code{1}.
 }
 \item Save the edited file as, say, \emph{valid_matches.csv}.
 }

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -587,3 +587,12 @@ test_that("matches any case of ald$name_company, but preserves original case", {
   # The original uppercase is preserved
   expect_equal(upp$name_ald, "ALPINE KNITS")
 })
+
+test_that("with relevant options allows loanbook with reserved columns", {
+  restore <- options(allow_reserved_columns = TRUE)
+  on.exit(options(restore), add = TRUE, after = FALSE)
+
+  # Must add both `sector` and `borderline` -- match_name errors with just one
+  lbk <- mutate(fake_lbk(), sector = "a", borderline = FALSE)
+  expect_no_error(suppressWarnings(match_name(lbk, fake_ald())))
+})

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -589,7 +589,7 @@ test_that("matches any case of ald$name_company, but preserves original case", {
 })
 
 test_that("with relevant options allows loanbook with reserved columns", {
-  restore <- options(allow_reserved_columns = TRUE)
+  restore <- options(r2dii.match.allow_reserved_columns = TRUE)
   on.exit(options(restore), add = TRUE)
 
   # Must add both `sector` and `borderline` -- match_name errors with just one

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -590,7 +590,7 @@ test_that("matches any case of ald$name_company, but preserves original case", {
 
 test_that("with relevant options allows loanbook with reserved columns", {
   restore <- options(allow_reserved_columns = TRUE)
-  on.exit(options(restore), add = TRUE, after = FALSE)
+  on.exit(options(restore), add = TRUE)
 
   # Must add both `sector` and `borderline` -- match_name errors with just one
   lbk <- mutate(fake_lbk(), sector = "a", borderline = FALSE)

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -594,5 +594,8 @@ test_that("with relevant options allows loanbook with reserved columns", {
 
   # Must add both `sector` and `borderline` -- match_name errors with just one
   lbk <- mutate(fake_lbk(), sector = "a", borderline = FALSE)
-  expect_no_error(suppressWarnings(match_name(lbk, fake_ald())))
+  expect_no_error(
+    # Don't warn if found no match
+    suppressWarnings(match_name(lbk, fake_ald()))
+  )
 })


### PR DESCRIPTION
Closes #326
Closes #327 -- this is a simpler/safer way to solve it.
Relates to:
* 2DegreesInvesting/r2dii.analysis#227
* 2DegreesInvesting/r2dii.analysis#230

This change is internal, and motivated by our need to break the
dependency between r2dii.data and its reverse dependencies. The
problem we are trying to solve is this:

r2dii.data provides data that is used in some functions of its
reverse dependencies -- like r2dii.match. Concretely, changes in
the sector classification dataset (in r2dii.data) make tests to
fail in reverse dependencies like r2dii.match that store a
snapshot of expected output (e.g. of match_name()).

This commit allows us to generate such snaphsots with a
"frozen loanbook" -- one that does not update with changes
to r2dii.data and instead has fixed columns `sector` and
borderline`.  This makes r2dii packages less prone to
meaningless errors when CRAN checks for reverse dependencies.