### PR TITLE
Avoid fragile test

### DIFF
--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -39,12 +39,17 @@ matched \%>\%
 
 Compare, edit, and save the data manually:
 \itemize{
-\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google Sheets, etc.).
-\item Compare the columns \code{name} and \code{name_ald} manually to determine if the match is valid. Other information can be used in conjunction with just the names to ensure the two entities match (sector, internal information on the company structure, etc.)
+\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google
+Sheets, etc.).
+\item Compare the columns \code{name} and \code{name_ald} manually to determine if
+the match is valid. Other information can be used in conjunction
+with just the names to ensure the two entities match (sector,
+internal information on the company structure, etc.)
 \item Edit the data:
 \itemize{
 \item If you are happy with the match, set the \code{score} value to \code{1}.
-\item Otherwise set or leave the \code{score} value to anything other than \code{1}.
+\item Otherwise set or leave the \code{score} value to anything other than
+\code{1}.
 }
 \item Save the edited file as, say, \emph{valid_matches.csv}.
 }

--- a/man/prioritize.Rd
+++ b/man/prioritize.Rd
@@ -39,17 +39,12 @@ matched \%>\%
 
 Compare, edit, and save the data manually:
 \itemize{
-\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google
-Sheets, etc.).
-\item Compare the columns \code{name} and \code{name_ald} manually to determine if
-the match is valid. Other information can be used in conjunction
-with just the names to ensure the two entities match (sector,
-internal information on the company structure, etc.)
+\item Open \emph{matched.csv} with any spreadsheet editor (Excel, Google Sheets, etc.).
+\item Compare the columns \code{name} and \code{name_ald} manually to determine if the match is valid. Other information can be used in conjunction with just the names to ensure the two entities match (sector, internal information on the company structure, etc.)
 \item Edit the data:
 \itemize{
 \item If you are happy with the match, set the \code{score} value to \code{1}.
-\item Otherwise set or leave the \code{score} value to anything other than
-\code{1}.
+\item Otherwise set or leave the \code{score} value to anything other than \code{1}.
 }
 \item Save the edited file as, say, \emph{valid_matches.csv}.
 }

--- a/tests/testthat/_snaps/prioritize.md
+++ b/tests/testthat/_snaps/prioritize.md
@@ -1,9 +1,0 @@
-# error if score=1 & values by id_loan+level are duplicated (#114)
-
-    Code
-      prioritize(invalid)
-    Error <duplicated_score1_by_id_loan_by_level>
-      `data` where `score` is `1` must be unique by `id_loan` by `level`.
-      Duplicated rows: 2.
-      Have you ensured that only one ald-name per loanbook-name is set to `1`?
-

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -210,8 +210,6 @@ test_that("error if score=1 & values by id_loan+level are duplicated (#114)", {
     class = "duplicated_score1_by_id_loan_by_level",
     prioritize(invalid)
   )
-
-  expect_snapshot(prioritize(invalid))
 })
 
 test_that("passes if score=1 & values by id_loan are duplicated for distinct


### PR DESCRIPTION
This PR is a hotfix to avoid a fragile test that fails on CRAN since testtaht 3.0.1 introduced `error` in `expect_snapshot()`. It touches no production code.