### PR TITLE
Print tibble-width consistently locally and on CI

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(r2dii.match)
+options(tibble.width=60)
 
 test_check("r2dii.match")

--- a/tests/testthat/_snaps/match_name.md
+++ b/tests/testthat/_snaps/match_name.md
@@ -9,13 +9,15 @@
       which most likely is a mistake.
     Output
       # A tibble: 1 x 15
-        sector_classifi~ id_ultimate_par~ name_ultimate_p~ id_direct_loant~
-        <chr>            <chr>            <chr>            <chr>           
-      1 NACE             UP15             Alpine Knits In~ C294            
-      # ... with 11 more variables: name_direct_loantaker <chr>,
-      #   sector_classification_direct_loantaker <dbl>, id_2dii <chr>, level <chr>,
-      #   sector <chr>, sector_ald <chr>, name <chr>, name_ald <chr>, score <dbl>,
-      #   source <chr>, borderline <lgl>
+        sector_classificati~ id_ultimate_par~ name_ultimate_parent
+        <chr>                <chr>            <chr>               
+      1 NACE                 UP15             Alpine Knits India ~
+      # ... with 12 more variables: id_direct_loantaker <chr>,
+      #   name_direct_loantaker <chr>,
+      #   sector_classification_direct_loantaker <dbl>,
+      #   id_2dii <chr>, level <chr>, sector <chr>,
+      #   sector_ald <chr>, name <chr>, name_ald <chr>,
+      #   score <dbl>, source <chr>, borderline <lgl>
 
 # works with UP266
 
@@ -23,12 +25,13 @@
       select(out, .data$id_2dii, matches(prefix))
     Output
       # A tibble: 2 x 7
-        id_2dii id_direct_loant~ name_direct_loa~ id_intermediate~ name_intermedia~
-        <chr>   <chr>            <chr>            <chr>            <chr>           
-      1 DL1     C38              Glencore Plc     <NA>             <NA>            
-      2 UP1     C38              Glencore Plc     <NA>             <NA>            
-      # ... with 2 more variables: id_ultimate_parent <chr>,
-      #   name_ultimate_parent <chr>
+        id_2dii id_direct_loant~ name_direct_loa~ id_intermediate~
+        <chr>   <chr>            <chr>            <chr>           
+      1 DL1     C38              Glencore Plc     <NA>            
+      2 UP1     C38              Glencore Plc     <NA>            
+      # ... with 3 more variables:
+      #   name_intermediate_parent_1 <chr>,
+      #   id_ultimate_parent <chr>, name_ultimate_parent <chr>
 
 # with loanbook_demo and ald_demo outputs expected value
 


### PR DESCRIPTION
This PR avoids false failures on CI due to small differences in the width of tibbles printed locally versus CI. Now we force a quite narrow width that should produce same results in both places. I expect less frequent false positives.

This PR touches no source code. It does accept failing snapshots but my visual inspection suggests the difference was only in the width. 