### PR TITLE
Move options() where testthat can see them

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
 library(r2dii.match)
-options(tibble.width=60)
 
 test_check("r2dii.match")

--- a/tests/testthat/helper-tibble.R
+++ b/tests/testthat/helper-tibble.R
@@ -1,0 +1,2 @@
+# Avoid failure on CI due to difference in print width between local vs. CI
+options(tibble.width = 60)


### PR DESCRIPTION
Follow https://github.com/2DegreesInvesting/r2dii.match/pull/357, as that PR used `options()` in the wrong place.