### PR TITLE
DON'T MERGE. Test that r2dii.match installs with the development version of stringdist

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,8 @@ jobs:
 
       - name: Install stringdist from GitHub
         run: |
-          pak::pkg_install("markvanderloo/stringdist", subdir = "pkg")
+          install.packages("remotes")
+          remotes::install_github("markvanderloo/stringdist", subdir = "pkg")
         shell: Rscript {0}
 
       - name: Install dependencies

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,6 +70,11 @@ jobs:
           pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
         shell: Rscript {0}
 
+      - name: Install stringdist from GitHub
+        run: |
+          pak::pkg_install("markvanderloo/stringdist")
+        shell: Rscript {0}
+
       - name: Install dependencies
         run: |
           pak::local_install_dev_deps(upgrade = TRUE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install stringdist from GitHub
         run: |
-          pak::pkg_install("markvanderloo/stringdist")
+          pak::pkg_install("markvanderloo/stringdist", subdir = "pkg")
         shell: Rscript {0}
 
       - name: Install dependencies

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -5,7 +5,7 @@
 #' `name_ultimate_parent`) with names in an asset-level dataset (column
 #' `name_company`). The raw names are first internally transformed, and aliases
 #' are assigned. The similarity between aliases in each of the loanbook and ald
-#' datasets is scored using [stringdist::stringsim()].
+#' datasets is scored using `stringdist::stringsim()`.
 #'
 #' @section Package options:
 #' `r2dii.match.sector_classifications`: Allows you to use your own
@@ -23,15 +23,14 @@
 #' @param min_score A number between 0-1, to set the minimum `score` threshold.
 #'   A `score` of 1 is a perfect match.
 #' @param method Method for distance calculation. One of `c("osa", "lv", "dl",
-#'   "hamming", "lcs", "qgram", "cosine", "jaccard", "jw", "soundex")`. See
-#'   [stringdist::stringdist-metrics].
-#' @inheritParams stringdist::stringdist
+#'   "hamming", "lcs", "qgram", "cosine", "jaccard", "jw", "soundex")`.
+#' @param p Passed on to `stringdist::stringdist()`.
 #' @param overwrite A data frame used to overwrite the `sector` and/or `name`
 #'   columns of a particular direct loantaker or ultimate parent. To overwrite
 #'   only `sector`, the value in the `name` column should be `NA` and
 #'   vice-versa. This file can be used to manually match loanbook companies to
 #'   ald.
-#' @param ... Arguments passed on to [stringdist::stringsim()].
+#' @param ... Arguments passed on to `stringdist::stringsim()`.
 #'
 #' @family main functions
 #'

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -25,12 +25,9 @@ same \code{sector}?}
 \item{min_score}{A number between 0-1, to set the minimum \code{score} threshold.
 A \code{score} of 1 is a perfect match.}
 
-\item{method}{Method for distance calculation. One of \code{c("osa", "lv", "dl", "hamming", "lcs", "qgram", "cosine", "jaccard", "jw", "soundex")}. See
-\link[stringdist:stringdist-metrics]{stringdist::stringdist-metrics}.}
+\item{method}{Method for distance calculation. One of \code{c("osa", "lv", "dl", "hamming", "lcs", "qgram", "cosine", "jaccard", "jw", "soundex")}.}
 
-\item{p}{Prefix factor for Jaro-Winkler distance. The valid range for 
-\code{p} is \code{0 <= p <= 0.25}. If \code{p=0} (default), the
-Jaro-distance is returned. Applies only to \code{method='jw'}.}
+\item{p}{Passed on to \code{stringdist::stringdist()}.}
 
 \item{overwrite}{A data frame used to overwrite the \code{sector} and/or \code{name}
 columns of a particular direct loantaker or ultimate parent. To overwrite
@@ -38,7 +35,7 @@ only \code{sector}, the value in the \code{name} column should be \code{NA} and
 vice-versa. This file can be used to manually match loanbook companies to
 ald.}
 
-\item{...}{Arguments passed on to \code{\link[stringdist:stringsim]{stringdist::stringsim()}}.}
+\item{...}{Arguments passed on to \code{stringdist::stringsim()}.}
 }
 \value{
 A data frame with the same groups (if any) and columns as \code{loanbook},
@@ -72,7 +69,7 @@ can be \code{name_direct_loantaker}, \verb{name_intermediate_parent*} and
 \code{name_ultimate_parent}) with names in an asset-level dataset (column
 \code{name_company}). The raw names are first internally transformed, and aliases
 are assigned. The similarity between aliases in each of the loanbook and ald
-datasets is scored using \code{\link[stringdist:stringsim]{stringdist::stringsim()}}.
+datasets is scored using \code{stringdist::stringsim()}.
 }
 \section{Package options}{
 


### PR DESCRIPTION
DON'T MERGE. 

This PR shows that r2dii.match installs successfully with the development version of stringdist. This means that the problem CRAN reported to us should go away if the maintariner of stringdist submits to CRAN what I now see on GitHub. 

I noticed a few strange things:

* stringdist is not stored in owner/repo but in owner/repo/pkg
* The package lacks man/ so the version I install from GitHub breaks the links to stringdist documentation, e.g. `[stringdist::stringsimg]`, `@inheritParams stringdist::stringdist`, and so on. Temporarily I removed all such links -- assuming this PR won't be merged.
 