### PR TITLE
Switch order of equality & condition expectations

### DIFF
--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -43,7 +43,7 @@ test_that("w/ missing values at all levels outputs 0-row", {
     alias_ald = "any",
   )
 
-  out <- expect_warning(match_name(lbk, ald), "no match")
+  expect_warning(out <- match_name(lbk, ald), "no match")
   expect_equal(nrow(out), 0L)
 })
 


### PR DESCRIPTION
In the dev version of testthat, we've tweaked `expect_warning()` and friends to return output that's [more consistent](https://github.com/r-lib/testthat/blob/master/NEWS.md#breaking-changes) with other testthat expectations. We'd like to get testthat on to CRAN in the near future, so I'd really appreciate it if you could merge this change and update your package on CRAN.