### PR TITLE
Simpler NEWS so we have less things to maintain

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,9 +42,6 @@ navbar:
     - text: "Using `match_name()` with large loanbooks"
       href: articles/chunk-your-data.html
 
-  - text: "News"
-    href: news/index.html
-
   right:
     - text: "Packages"
       menu:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,6 +42,14 @@ navbar:
     - text: "Using `match_name()` with large loanbooks"
       href: articles/chunk-your-data.html
 
+  - text: "News"
+    menu:
+    - text: "r2dii blog posts"
+      href: https://2degreesinvesting.github.io/#category:r2dii
+    - text: "----------------------"
+    - text: "Change log"
+      href: news/index.html
+
   right:
     - text: "Packages"
       menu:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -43,19 +43,7 @@ navbar:
       href: articles/chunk-your-data.html
 
   - text: "News"
-    menu:
-    - text: "Releases"
-    - text: "Version 0.0.4"
-      href: https://2degreesinvesting.github.io/posts/2020-08-14-r2dii-data-0-1-2-and-r2dii-match-0-0-4-are-now-on-cran/
-    - text: "Version 0.0.3"
-      href: https://2degreesinvesting.github.io/r2dii.match/news/index.html#r2dii-match-0-0-3-2020-06-30
-    - text: "Version 0.0.2"
-      href: https://2degreesinvesting.github.io/posts/2020-06-05-r2dii-match-0-0-2/
-    - text: "Version 0.0.1"
-      href: articles/r2dii-match-0-0-1.html
-    - text: "----------------------"
-    - text: "Change log"
-      href: news/index.html
+    href: news/index.html
 
   right:
     - text: "Packages"


### PR DESCRIPTION
The News menu has a "Releases" section that I now find confusing
because there are more releases than entries under News/Releases,
pointing to external articles. But we don't write articles for
most small patches.

This PR removes the headings "Releases" and "Changelog", to
instead expose the changelog directly under the News navbar.

Alternativelly, we may rename the heading from "Releases" to
"Announcements" (which is less confusing), and/or add a single
link to the blog.

--

I'm asking for a review of the equivalent change in r2dii.analysis. I'll keep this one in draft until that review is done, then apply the decision here too.
